### PR TITLE
Drop quickspec dependency, GHC9

### DIFF
--- a/.github/workflows/ci.dhall
+++ b/.github/workflows/ci.dhall
@@ -4,7 +4,8 @@ in    haskellCi.generalCi
         haskellCi.matrixSteps
         ( Some
             { ghc =
-              [ haskellCi.GHC.GHC8104
+              [ haskellCi.GHC.GHC902
+              , haskellCi.GHC.GHC8107
               , haskellCi.GHC.GHC884
               , haskellCi.GHC.GHC865
               ]

--- a/.github/workflows/ci.dhall
+++ b/.github/workflows/ci.dhall
@@ -9,7 +9,7 @@ in    haskellCi.generalCi
               , haskellCi.GHC.GHC884
               , haskellCi.GHC.GHC865
               ]
-            , cabal = [ haskellCi.Cabal.Cabal32 ]
+            , cabal = [ haskellCi.Cabal.Cabal34 ]
             }
         )
         // { on = [ haskellCi.Event.push

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         cabal:
-          - '3.2'
+          - '3.4'
         ghc:
           - '9.0.2'
           - '8.10.7'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,19 @@ jobs:
           ghc-version: "${{ matrix.ghc }}"
       - name: Update Hackage repository
         run: cabal update
+      - name: cabal.project.local.ci
+        run: |
+          if [ -e cabal.project.local.ci ]; then
+            cp cabal.project.local.ci cabal.project.local
+          fi
       - name: freeze
         run: cabal freeze
       - uses: "actions/cache@v2"
         with:
           key: "${{ runner.os }}-${{ matrix.ghc }}-cabal-${{ hashFiles('cabal.project.freeze') }}"
-          path: "${{ steps.setup-haskell-cabal.outputs.cabal-store }} dist-newstyle"
+          path: |
+            ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+            dist-newstyle
       - name: Install dependencies
         run: cabal build all --enable-tests --enable-benchmarks --only-dependencies
       - name: build all
@@ -30,7 +37,8 @@ jobs:
         cabal:
           - '3.2'
         ghc:
-          - '8.10.4'
+          - '9.0.2'
+          - '8.10.7'
           - '8.8.4'
           - '8.6.5'
 name: Haskell CI

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -17,7 +17,6 @@ module Graphics.Implicit.Definitions (
     module N,
     ℝ,
     ℝ2,
-    both,
     ℝ3,
     minℝ,
     ComponentWiseMultable,
@@ -107,11 +106,6 @@ minℝ :: ℝ
 minℝ = 0.0000000000000002
 -- for Floats.
 --minℝ = 0.00000011920928955078125 * 2
-
--- | apply a function to both items in the provided tuple.
-both :: (t -> b) -> (t, t) -> (b, b)
-both f (x,y) = (f x, f y)
-{-# INLINABLE both #-}
 
 -- Wrap the functions that convert datatypes.
 

--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,10 @@ packages: .
 
 package zlib
   flags: +pkg-config
+
+-- for GHC9+, until
+-- * https://github.com/snapframework/snap-server/issues/141
+-- * https://github.com/snapframework/io-streams-haproxy/pull/24
+allow-newer:
+    snap-server:base
+  , io-streams-haproxy:base

--- a/cabal.project.local.ci
+++ b/cabal.project.local.ci
@@ -1,0 +1,1 @@
+flags: +implicitsnap

--- a/implicit.cabal
+++ b/implicit.cabal
@@ -223,7 +223,6 @@ Test-suite test-implicit
                   directory,
                   hedgehog,
                   hw-hspec-hedgehog,
-                  quickspec,
                   QuickCheck,
                   linear,
                   lens

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -34,13 +34,13 @@ import Test.QuickCheck
       forAll)
 import Data.Foldable ( for_ )
 import Test.Hspec.QuickCheck (prop)
-import QuickSpec (Observe)
 import Linear ( V3(V3), (^*) )
 import Graphics.Implicit (unionR)
 import Graphics.Implicit (intersectR)
 import Graphics.Implicit (extrude)
 import Graphics.Implicit (cylinder2)
 import Graphics.Implicit (mirror)
+import Graphics.Implicit.Test.Instances
 
 ------------------------------------------------------------------------------
 -- Tests showing equivalencies between algebraic formulations of symbolic


### PR DESCRIPTION
and couple more bits. Most notably CI builds `implicitsnap` as well.

cc @isovector 