### PR TITLE
`-fspecialise-aggressively`, CI `-Werror`

### DIFF
--- a/cabal.project.local.ci
+++ b/cabal.project.local.ci
@@ -1,1 +1,4 @@
 flags: +implicitsnap
+
+package implicit
+  ghc-options: -fspecialise-aggressively -Werror


### PR DESCRIPTION
This seems to specialise imported functions so we no longer get warnings like

```
./Graphics/Implicit/IntegralUtil.hs: warning: [-Wall-missed-specialisations]
    Could not specialise imported function ‘GHC.Real.$wfromIntegral’
      when specialising ‘fromIntegral’
    Probable fix: add INLINABLE pragma on ‘GHC.Real.$wfromIntegral’
```

and we can enable `-Werror` for CI builds since there are no other warnings \o/

From the dosc of the flag:

> By default only type class methods and methods marked INLINABLE or INLINE are specialised. This flag will specialise any overloaded function regardless of size if its unfolding is available. This flag is not included in any optimisation level as it can massively increase code size. It can be used in conjunction with [-fexpose-all-unfoldings](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/using-optimisation.html#ghc-flag--fexpose-all-unfoldings) if you want to ensure all calls are specialised.

The impact on on binary size (`extopenscad`) seems to be less than 0.1MB. Not sure about performance impact.