### PR TITLE
Transform3 for multmatrix

### DIFF
--- a/Examples/exampleMultmatrix.scad
+++ b/Examples/exampleMultmatrix.scad
@@ -1,0 +1,36 @@
+// Examples from
+// https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Transformations#multmatrix
+// CC-BY-SA 3.0 https://creativecommons.org/licenses/by-sa/3.0/
+
+angle=PI/4;
+multmatrix(m = [ [cos(angle), -sin(angle), 0,  0],
+                 [sin(angle),  cos(angle), 0, 30],
+                 [         0,           0, 1,  0],
+                 [         0,           0, 0,  1]
+               ] )
+union() {
+   cylinder(r=10.0,h=10,center=false);
+   cube(size=[10,10,10],center=false);
+}
+
+// skew
+M = [ [ 1  , 0  , 0  , 0   ],
+      [ 0  , 1  , 0.7, 0   ],  // The "0.7" is the skew value; pushed along the y axis as z changes.
+      [ 0  , 0  , 1  , 0   ],
+      [ 0  , 0  , 0  , 1   ] ] ;
+translate([-20,0,0])
+multmatrix(M) {  union() {
+    cylinder(r=10.0,h=10,center=false);
+    cube(size=[10,10,10],center=false);
+} }
+
+// same as previous example but using 3x4 matrix
+N = [ [ 1  , 0  , 0  , 0   ],
+      [ 0  , 1  , 0.7, 0   ],  // The "0.7" is the skew value; pushed along the y axis as z changes.
+      [ 0  , 0  , 1  , 0   ] ] ;
+translate([20,0,0])
+multmatrix(N) {  union() {
+    cylinder(r=10.0,h=10,center=false);
+    cube(size=[10,10,10],center=false);
+} }
+

--- a/Graphics/Implicit.hs
+++ b/Graphics/Implicit.hs
@@ -56,6 +56,7 @@ module Graphics.Implicit (
   P.rotate3,
   P.rotate3V,
   P.pack3,
+  P.transform3,
 
   -- * Extrusions into 3D
   P.extrude,
@@ -92,7 +93,7 @@ import Prelude(FilePath, IO)
 
 -- The primitive objects, and functions for manipulating them.
 -- MAYBEFIXME: impliment slice operation, regularPolygon and zsurface primitives.
-import Graphics.Implicit.Primitives as P (withRounding, rect, rect3, translate, scale, mirror, complement, union, intersect, difference, unionR, intersectR, differenceR, shell, extrude, extrudeM, extrudeOnEdgeOf, sphere, cube, circle, cylinder, cylinder2, square, polygon, rotateExtrude, rotate3, rotate3V, pack3, rotate, pack2, implicit, fullSpace, emptySpace, outset, Object)
+import Graphics.Implicit.Primitives as P (withRounding, rect, rect3, translate, scale, mirror, complement, union, intersect, difference, unionR, intersectR, differenceR, shell, extrude, extrudeM, extrudeOnEdgeOf, sphere, cube, circle, cylinder, cylinder2, square, polygon, rotateExtrude, rotate3, rotate3V, pack3, transform3, rotate, pack2, implicit, fullSpace, emptySpace, outset, Object)
 
 -- The Extended OpenScad interpreter.
 import Graphics.Implicit.ExtOpenScad as E (runOpenscad)

--- a/Graphics/Implicit.hs
+++ b/Graphics/Implicit.hs
@@ -43,6 +43,7 @@ module Graphics.Implicit (
 
   -- * 2D operations
   P.rotate,
+  P.transform,
   P.pack2,
 
   -- * 3D primitive shapes
@@ -93,7 +94,7 @@ import Prelude(FilePath, IO)
 
 -- The primitive objects, and functions for manipulating them.
 -- MAYBEFIXME: impliment slice operation, regularPolygon and zsurface primitives.
-import Graphics.Implicit.Primitives as P (withRounding, rect, rect3, translate, scale, mirror, complement, union, intersect, difference, unionR, intersectR, differenceR, shell, extrude, extrudeM, extrudeOnEdgeOf, sphere, cube, circle, cylinder, cylinder2, square, polygon, rotateExtrude, rotate3, rotate3V, pack3, transform3, rotate, pack2, implicit, fullSpace, emptySpace, outset, Object)
+import Graphics.Implicit.Primitives as P (withRounding, rect, rect3, translate, scale, mirror, complement, union, intersect, difference, unionR, intersectR, differenceR, shell, extrude, extrudeM, extrudeOnEdgeOf, sphere, cube, circle, cylinder, cylinder2, square, polygon, rotateExtrude, rotate3, rotate3V, pack3, transform3, rotate, transform, pack2, implicit, fullSpace, emptySpace, outset, Object)
 
 -- The Extended OpenScad interpreter.
 import Graphics.Implicit.ExtOpenScad as E (runOpenscad)

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -44,6 +44,7 @@ module Graphics.Implicit.Definitions (
         Circle,
         Polygon,
         Rotate2,
+        Transform2,
         Shared2),
     SymbolicObj3(
         Cube,
@@ -78,7 +79,7 @@ import Graphics.Implicit.IntegralUtil as N (ℕ, fromℕ, toℕ)
 
 import Control.DeepSeq (NFData, rnf)
 
-import Linear (M44, V2(V2), V3(V3))
+import Linear (M33, M44, V2(V2), V3(V3))
 
 import Linear.Quaternion (Quaternion(Quaternion))
 
@@ -271,6 +272,7 @@ data SymbolicObj2 =
     | Polygon [ℝ2]  -- points.
     -- Simple transforms
     | Rotate2 ℝ SymbolicObj2
+    | Transform2 (M33 ℝ) SymbolicObj2
     -- Lifting common objects
     | Shared2 (SharedObj SymbolicObj2 ℝ2)
     deriving (Generic)
@@ -284,6 +286,7 @@ instance Show SymbolicObj2 where
     Circle r      -> showCon "circle" @| r
     Polygon ps -> showCon "polygon"   @| ps
     Rotate2 v obj -> showCon "rotate" @| v     @| obj
+    Transform2 m obj -> showCon "transform2" @| m     @| obj
     Shared2 obj   -> flip showsPrec obj
 
 -- | Semigroup under 'Graphic.Implicit.Primitives.union'.

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -50,6 +50,7 @@ module Graphics.Implicit.Definitions (
         Sphere,
         Cylinder,
         Rotate3,
+        Transform3,
         Extrude,
         ExtrudeM,
         ExtrudeOnEdgeOf,
@@ -77,7 +78,7 @@ import Graphics.Implicit.IntegralUtil as N (ℕ, fromℕ, toℕ)
 
 import Control.DeepSeq (NFData, rnf)
 
-import Linear (V2(V2), V3(V3))
+import Linear (M44, V2(V2), V3(V3))
 
 import Linear.Quaternion (Quaternion(Quaternion))
 
@@ -301,6 +302,7 @@ data SymbolicObj3 =
     | Cylinder ℝ ℝ ℝ --
     -- Simple transforms
     | Rotate3 (Quaternion ℝ) SymbolicObj3
+    | Transform3 (M44 ℝ) SymbolicObj3
     -- 2D based
     | Extrude SymbolicObj2 ℝ
     | ExtrudeM
@@ -332,6 +334,7 @@ instance Show SymbolicObj3 where
     Cylinder h r1 r2 ->
       showCon "cylinder2" @| r1 @| r2 @| h
     Rotate3 qd s -> showCon "rotate3" @| quaternionToEuler qd @| s
+    Transform3 m s -> showCon "transform3" @| show m @| s
     Extrude s d2 -> showCon "extrude" @| s @| d2
     ExtrudeM edfdd e ep_ddfdp_dd s edfp_ddd ->
       showCon "extrudeM" @|| edfdd @| e @|| ep_ddfdp_dd @| s @|| edfp_ddd

--- a/Graphics/Implicit/Export/SymbolicFormats.hs
+++ b/Graphics/Implicit/Export/SymbolicFormats.hs
@@ -178,8 +178,7 @@ buildS2 (Polygon points) = call "polygon" (fmap bvect points) []
 
 buildS2 (Rotate2 r obj)     = call "rotate" [bf (rad2deg r)] [buildS2 obj]
 
--- Generate errors for rounding requests. OpenSCAD does not support rounding.
-buildS2 Square{} = error "cannot provide roundness when exporting openscad; unsupported in target format."
+buildS2 (Square (V2 w h)) = call "square" [bf w, bf h] []
 
 -- FIXME: missing EmbedBoxedObj2?
 

--- a/Graphics/Implicit/Export/SymbolicFormats.hs
+++ b/Graphics/Implicit/Export/SymbolicFormats.hs
@@ -141,8 +141,6 @@ buildS3 (Transform3 m obj) =
       ((\x -> "["<>x<>"]") . fold . intersperse "," . fmap bf . toList <$> toList m)
       [buildS3 obj]
 
--- FIXME: where is EmbedBoxedObj3?
-
 buildS3 (Extrude obj h) = callNaked "linear_extrude" ["height = " <> bf h] [buildS2 obj]
 
 -- FIXME: handle scale, center.
@@ -191,6 +189,4 @@ buildS2 (Transform2 m obj) =
       [buildS2 obj]
 
 buildS2 (Square (V2 w h)) = call "square" [bf w, bf h] []
-
--- FIXME: missing EmbedBoxedObj2?
 

--- a/Graphics/Implicit/Export/SymbolicFormats.hs
+++ b/Graphics/Implicit/Export/SymbolicFormats.hs
@@ -12,7 +12,7 @@ module Graphics.Implicit.Export.SymbolicFormats (scad2, scad3) where
 
 import Prelude((.), fmap, Either(Left, Right), ($), (*), ($!), (-), (/), pi, error, (+), (==), take, floor, (&&), const, pure, (<>), sequenceA, (<$>))
 
-import Graphics.Implicit.Definitions(ℝ, SymbolicObj2(Shared2, Square, Circle, Polygon, Rotate2), SymbolicObj3(Shared3, Cube, Sphere, Cylinder, Rotate3, Extrude, ExtrudeM, RotateExtrude, ExtrudeOnEdgeOf), isScaleID, SharedObj(Empty, Full, Complement, UnionR, IntersectR, DifferenceR, Translate, Scale, Mirror, Outset, Shell, EmbedBoxedObj, WithRounding), quaternionToEuler)
+import Graphics.Implicit.Definitions(ℝ, SymbolicObj2(Shared2, Square, Circle, Polygon, Rotate2), SymbolicObj3(Shared3, Cube, Sphere, Cylinder, Rotate3, Transform3, Extrude, ExtrudeM, RotateExtrude, ExtrudeOnEdgeOf), isScaleID, SharedObj(Empty, Full, Complement, UnionR, IntersectR, DifferenceR, Translate, Scale, Mirror, Outset, Shell, EmbedBoxedObj, WithRounding), quaternionToEuler)
 import Graphics.Implicit.Export.TextBuilderUtils(Text, Builder, toLazyText, fromLazyText, bf)
 
 import Control.Monad.Reader (Reader, runReader, ask)
@@ -22,7 +22,7 @@ import Linear (V3(V3), V2(V2))
 
 import Data.List (intersperse)
 import Data.Function (fix)
-import Data.Foldable(fold, foldMap)
+import Data.Foldable(fold, foldMap, toList)
 import Graphics.Implicit.ObjectUtil.GetBoxShared (VectorStuff(elements))
 
 default (ℝ)
@@ -135,6 +135,11 @@ buildS3 (Cylinder h r1 r2) = callNaked "cylinder" [
 buildS3 (Rotate3 q obj) =
   let (x,y,z) = quaternionToEuler q
    in call "rotate" [bf (rad2deg x), bf (rad2deg y), bf (rad2deg z)] [buildS3 obj]
+
+buildS3 (Transform3 m obj) =
+    call "multmatrix"
+      ((\x -> "["<>x<>"]") . fold . intersperse "," . fmap bf . toList <$> toList m)
+      [buildS3 obj]
 
 -- FIXME: where is EmbedBoxedObj3?
 

--- a/Graphics/Implicit/ExtOpenScad/Primitives.hs
+++ b/Graphics/Implicit/ExtOpenScad/Primitives.hs
@@ -31,13 +31,13 @@ import Graphics.Implicit.ExtOpenScad.Util.OVal (OTypeMirror, caseOType, divideOb
 import Graphics.Implicit.ExtOpenScad.Util.StateC (errorC)
 
 -- Note the use of a qualified import, so we don't have the functions in this file conflict with what we're importing.
-import qualified Graphics.Implicit.Primitives as Prim (withRounding, sphere, rect3, rect, translate, circle, polygon, extrude, cylinder2, union, unionR, intersect, intersectR, difference, differenceR, rotate, rotate3V, rotate3, scale, extrudeM, rotateExtrude, shell, mirror, pack3, pack2)
+import qualified Graphics.Implicit.Primitives as Prim (withRounding, sphere, rect3, rect, translate, circle, polygon, extrude, cylinder2, union, unionR, intersect, intersectR, difference, differenceR, rotate, rotate3V, rotate3, transform3, scale, extrudeM, rotateExtrude, shell, mirror, pack3, pack2)
 
 import Control.Monad (when, mplus)
 
 import Data.Text.Lazy (Text)
 
-import Linear ( V3(V3), V2(V2) )
+import Linear (M34, M44, V2(V2), V3(V3), V4(V4))
 import Linear.Affine (qdA)
 
 default (ℝ)
@@ -69,6 +69,7 @@ primitiveModules =
   , onModIze pack [([("size", noDefault), ("sep", noDefault)], requiredSuite)]
   , onModIze unit [([("unit", noDefault)], requiredSuite)]
   , onModIze mirror [([("x", noDefault), ("y", noDefault), ("z", noDefault)], requiredSuite), ([("v", noDefault)], requiredSuite)]
+  , onModIze multmatrix [([("m", noDefault)], requiredSuite)]
   ]
   where
     hasDefault = True
@@ -587,6 +588,20 @@ mirror = moduleWithSuite "mirror" $ \_ children -> do
                 Right (Right (V3 x y z)) -> V3 x y z
     pure $ pure $
         objMap (Prim.mirror (V2 x y)) (Prim.mirror (V3 x y z)) children
+
+multmatrix :: (Symbol, SourcePosition -> [OVal] -> ArgParser (StateC [OVal]))
+multmatrix = moduleWithSuite "multmatrix" $ \_ children -> do
+    example "multmatrix (m=[[1,0,0,0],[0,1,0,0],[0,0,1,0]]) cube(3);"
+    example "multmatrix (m=[[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]) cube(3);"
+    m <-
+        do
+            m :: Either (M34 ℝ) (M44 ℝ) <- argument "m"
+                `doc` "3x4 or 4x4 matrix representing affine transformation";
+            pure $ case m of
+              Left (V3 a b c) -> V4 a b c (V4 0 0 0 1)
+              Right m44 -> m44
+    pure $ pure $
+        objMap id (Prim.transform3 m) children
 
 ---------------
 

--- a/Graphics/Implicit/ExtOpenScad/Primitives.hs
+++ b/Graphics/Implicit/ExtOpenScad/Primitives.hs
@@ -31,13 +31,14 @@ import Graphics.Implicit.ExtOpenScad.Util.OVal (OTypeMirror, caseOType, divideOb
 import Graphics.Implicit.ExtOpenScad.Util.StateC (errorC)
 
 -- Note the use of a qualified import, so we don't have the functions in this file conflict with what we're importing.
-import qualified Graphics.Implicit.Primitives as Prim (withRounding, sphere, rect3, rect, translate, circle, polygon, extrude, cylinder2, union, unionR, intersect, intersectR, difference, differenceR, rotate, rotate3V, rotate3, transform3, scale, extrudeM, rotateExtrude, shell, mirror, pack3, pack2)
+import qualified Graphics.Implicit.Primitives as Prim (withRounding, sphere, rect3, rect, translate, circle, polygon, extrude, cylinder2, union, unionR, intersect, intersectR, difference, differenceR, rotate, transform, rotate3V, rotate3, transform3, scale, extrudeM, rotateExtrude, shell, mirror, pack3, pack2)
 
 import Control.Monad (when, mplus)
 
 import Data.Text.Lazy (Text)
 
-import Linear (M34, M44, V2(V2), V3(V3), V4(V4))
+import Control.Lens ((^.))
+import Linear (_m33, M34, M44, V2(V2), V3(V3), V4(V4))
 import Linear.Affine (qdA)
 
 default (ℝ)
@@ -601,7 +602,8 @@ multmatrix = moduleWithSuite "multmatrix" $ \_ children -> do
               Left (V3 a b c) -> V4 a b c (V4 0 0 0 1)
               Right m44 -> m44
     pure $ pure $
-        objMap id (Prim.transform3 m) children
+        -- m44 -> m33
+        objMap (Prim.transform (m ^. Linear._m33)) (Prim.transform3 m) children
 
 ---------------
 

--- a/Graphics/Implicit/ExtOpenScad/Util/OVal.hs
+++ b/Graphics/Implicit/ExtOpenScad/Util/OVal.hs
@@ -33,7 +33,7 @@ import Data.Text.Lazy (Text)
 import Control.Parallel.Strategies (runEval, rpar, rseq)
 
 -- To build vectors of ℝs.
-import Linear (V2(V2), V3(V3))
+import Linear (V2(V2), V3(V3), V4(V4))
 
 -- Convert OVals (and Lists of OVals) into a given Haskell type
 class OTypeMirror a where
@@ -108,6 +108,13 @@ instance (OTypeMirror a) => OTypeMirror (V3 a) where
     fromOObj _ = Nothing
     {-# INLINABLE fromOObj #-}
     toOObj (V3 a b c) = OList [toOObj a, toOObj b, toOObj c]
+
+instance (OTypeMirror a) => OTypeMirror (V4 a) where
+    fromOObj (OList [fromOObj -> Just a,fromOObj -> Just b,fromOObj -> Just c,fromOObj -> Just d]) =
+        Just (V4 a b c d)
+    fromOObj _ = Nothing
+    {-# INLINABLE fromOObj #-}
+    toOObj (V4 a b c d) = OList [toOObj a, toOObj b, toOObj c, toOObj d]
 
 instance (OTypeMirror a, OTypeMirror b) => OTypeMirror (a -> b) where
     fromOObj (OFunc f) =  Just $ \input ->

--- a/Graphics/Implicit/ObjectUtil/GetBox2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox2.hs
@@ -5,10 +5,10 @@
 
 module Graphics.Implicit.ObjectUtil.GetBox2 (getBox2, getBox2R) where
 
-import Prelude(pure, fmap, Eq, (==), (||), unzip, minimum, maximum, ($), (/), (-), (+), (*), cos, sin, sqrt, min, max, (<), (<>), pi, atan2, (==), (>), show, (&&), otherwise, error)
+import Prelude(pure, fmap, Eq, (==), (.), (<$>), (||), unzip, minimum, maximum, ($), (/), (-), (+), (*), cos, sin, sqrt, min, max, (<), (<>), pi, atan2, (==), (>), show, (&&), otherwise, error)
 
 import Graphics.Implicit.Definitions
-    ( SymbolicObj2(Square, Circle, Polygon, Rotate2, Shared2),
+    ( SymbolicObj2(Square, Circle, Polygon, Rotate2, Transform2, Shared2),
       SharedObj(IntersectR, Complement, UnionR, DifferenceR),
       Box2,
       ℝ2,
@@ -20,7 +20,8 @@ import Data.Fixed (mod')
 import Graphics.Implicit.ObjectUtil.GetBoxShared (emptyBox, corners, outsetBox, intersectBoxes, pointsBox, getBoxShared, unionBoxes)
 
 -- To construct vectors of ℝs.
-import Linear (V2(V2))
+import Linear (V2(V2), V3(V3))
+import qualified Linear
 
 -- Get a Box2 around the given object.
 getBox2 :: SymbolicObj2 -> Box2
@@ -33,6 +34,11 @@ getBox2 (Polygon points) = pointsBox points
 getBox2 (Rotate2 θ symbObj) =
     let rotate (V2 x y) = V2 (x*cos θ - y*sin θ) (x*sin θ + y*cos θ)
      in pointsBox $ fmap rotate $ corners $ getBox2 symbObj
+getBox2 (Transform2 m symbObj) =
+    let box = getBox2 symbObj
+        augment (V2 x y) = (V3 x y 1)
+        normalize (V3 x y w) = (V2 (x/w) (y/w))
+     in pointsBox $ normalize . (m Linear.!*) . augment <$> corners box
 getBox2 (Shared2 obj) = getBoxShared obj
 
 -- | Define a Box2 around the given object, and the space it occupies while rotating about the center point.

--- a/Graphics/Implicit/ObjectUtil/GetBox3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox3.hs
@@ -12,7 +12,7 @@ import Graphics.Implicit.Definitions
     ( Fastℕ,
       fromFastℕ,
       ExtrudeMScale(C2, C1),
-      SymbolicObj3(Shared3, Cube, Sphere, Cylinder, Rotate3, Extrude, ExtrudeOnEdgeOf, ExtrudeM, RotateExtrude),
+      SymbolicObj3(Shared3, Cube, Sphere, Cylinder, Rotate3, Transform3, Extrude, ExtrudeOnEdgeOf, ExtrudeM, RotateExtrude),
       Box3,
       ℝ,
       fromFastℕtoℝ,
@@ -20,7 +20,8 @@ import Graphics.Implicit.Definitions
 
 import Graphics.Implicit.ObjectUtil.GetBox2 (getBox2, getBox2R)
 
-import qualified Linear.Quaternion as Q
+-- TODO as L or no as
+import qualified Linear as Q
 import Graphics.Implicit.ObjectUtil.GetBoxShared (corners, pointsBox, getBoxShared)
 
 import Linear (V2(V2), V3(V3))
@@ -39,6 +40,9 @@ getBox3 (Cylinder h r1 r2) = (V3 (-r) (-r) 0, V3 r r h ) where r = max r1 r2
 getBox3 (Rotate3 q symbObj) =
     let box = getBox3 symbObj
      in pointsBox $ Q.rotate q <$> corners box
+getBox3 (Transform3 m symbObj) =
+    let box = getBox3 symbObj
+     in pointsBox $ Q.normalizePoint . (m Q.!*) . Q.point <$> corners box
 -- Misc
 -- 2D Based
 getBox3 (Extrude symbObj h) = (V3 x1 y1 0, V3 x2 y2 h)

--- a/Graphics/Implicit/ObjectUtil/GetBox3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox3.hs
@@ -20,11 +20,10 @@ import Graphics.Implicit.Definitions
 
 import Graphics.Implicit.ObjectUtil.GetBox2 (getBox2, getBox2R)
 
--- TODO as L or no as
-import qualified Linear as Q
 import Graphics.Implicit.ObjectUtil.GetBoxShared (corners, pointsBox, getBoxShared)
 
 import Linear (V2(V2), V3(V3))
+import qualified Linear
 
 -- FIXME: many variables are being ignored here. no rounding for intersect, or difference.. etc.
 
@@ -39,10 +38,10 @@ getBox3 (Cylinder h r1 r2) = (V3 (-r) (-r) 0, V3 r r h ) where r = max r1 r2
 -- Simple transforms
 getBox3 (Rotate3 q symbObj) =
     let box = getBox3 symbObj
-     in pointsBox $ Q.rotate q <$> corners box
+     in pointsBox $ Linear.rotate q <$> corners box
 getBox3 (Transform3 m symbObj) =
     let box = getBox3 symbObj
-     in pointsBox $ Q.normalizePoint . (m Q.!*) . Q.point <$> corners box
+     in pointsBox $ Linear.normalizePoint . (m Linear.!*) . Linear.point <$> corners box
 -- Misc
 -- 2D Based
 getBox3 (Extrude symbObj h) = (V3 x1 y1 0, V3 x2 y2 h)

--- a/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit2.hs
@@ -11,14 +11,15 @@ module Graphics.Implicit.ObjectUtil.GetImplicit2 (getImplicit2) where
 import Prelude(cycle, (/=), uncurry, fst, Eq, zip, drop, abs, (-), (/), sqrt, (*), (+), length, fmap, (<=), (&&), (>=), (||), odd, ($), (>), filter, (<), minimum, (.), sin, cos)
 
 import Graphics.Implicit.Definitions
-    ( objectRounding, ObjectContext, SymbolicObj2(Square, Circle, Polygon, Rotate2, Shared2), SharedObj (Empty), Obj2, ℝ2, ℝ )
+    ( objectRounding, ObjectContext, SymbolicObj2(Square, Circle, Polygon, Rotate2, Transform2, Shared2), SharedObj (Empty), Obj2, ℝ2, ℝ )
 
 import Graphics.Implicit.MathUtil
     ( distFromLineSeg, rmaximum )
 
 import Data.List (nub)
 import Graphics.Implicit.ObjectUtil.GetImplicitShared (getImplicitShared)
-import Linear (V2(V2))
+import Linear (V2(V2), V3(V3))
+import qualified Linear
 
 ------------------------------------------------------------------------------
 -- | Filter out equal consecutive elements in the list. This function will
@@ -64,4 +65,12 @@ getImplicit2 ctx (Rotate2 θ symbObj) =
         obj = getImplicit2 ctx symbObj
     in
         obj $ V2 (x*cos θ + y*sin θ) (y*cos θ - x*sin θ)
+getImplicit2 ctx (Transform2 m symbObj) =
+    \vin ->
+    let
+        obj = getImplicit2 ctx symbObj
+        augment (V2 x y) = (V3 x y 1)
+        normalize (V3 x y w) = (V2 (x/w) (y/w))
+    in
+        obj $ (normalize . ((Linear.inv33 m) Linear.!*) . augment $ vin)
 getImplicit2 ctx (Shared2 obj) = getImplicitShared ctx obj

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -13,13 +13,13 @@ import Graphics.Implicit.Definitions
 
 import Graphics.Implicit.MathUtil ( rmax, rmaximum )
 
-import qualified Linear as Q
-
 import qualified Data.Either as Either (either)
 
 -- Use getImplicit for handling extrusion of 2D shapes to 3D.
 import Graphics.Implicit.ObjectUtil.GetImplicitShared (getImplicitShared)
 import Linear (V2(V2), V3(V3))
+import qualified Linear
+
 import {-# SOURCE #-} Graphics.Implicit.Primitives (getImplicit)
 
 default (ℝ)
@@ -39,9 +39,9 @@ getImplicit3 _ (Cylinder h r1 r2) = \(V3 x y z) ->
         max (d * cos θ) (abs (z-h/2) - (h/2))
 -- Simple transforms
 getImplicit3 ctx (Rotate3 q symbObj) =
-    getImplicit3 ctx symbObj . Q.rotate (Q.conjugate q)
+    getImplicit3 ctx symbObj . Linear.rotate (Linear.conjugate q)
 getImplicit3 ctx (Transform3 m symbObj) =
-    getImplicit3 ctx symbObj . Q.normalizePoint . ((Q.inv44 m) Q.!*) . Q.point
+    getImplicit3 ctx symbObj . Linear.normalizePoint . ((Linear.inv44 m) Linear.!*) . Linear.point
 -- 2D Based
 getImplicit3 ctx (Extrude symbObj h) =
     let

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -9,7 +9,7 @@ module Graphics.Implicit.ObjectUtil.GetImplicit3 (getImplicit3) where
 import Prelude (id, (||), (/=), either, round, fromInteger, Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, cos, minimum, ($), sin, pi, (.), Bool(True, False), ceiling, floor, pure, (==), otherwise)
 
 import Graphics.Implicit.Definitions
-    ( objectRounding, ObjectContext, ℕ, SymbolicObj3(Cube, Sphere, Cylinder, Rotate3, Extrude, ExtrudeM, ExtrudeOnEdgeOf, RotateExtrude, Shared3), Obj3, ℝ2, ℝ, fromℕtoℝ, toScaleFn )
+    ( objectRounding, ObjectContext, ℕ, SymbolicObj3(Cube, Sphere, Cylinder, Rotate3, Transform3, Extrude, ExtrudeM, ExtrudeOnEdgeOf, RotateExtrude, Shared3), Obj3, ℝ2, ℝ, fromℕtoℝ, toScaleFn )
 
 import Graphics.Implicit.MathUtil ( rmax, rmaximum )
 
@@ -40,7 +40,8 @@ getImplicit3 _ (Cylinder h r1 r2) = \(V3 x y z) ->
 -- Simple transforms
 getImplicit3 ctx (Rotate3 q symbObj) =
     getImplicit3 ctx symbObj . Q.rotate (Q.conjugate q)
-
+getImplicit3 ctx (Transform3 m symbObj) =
+    getImplicit3 ctx symbObj . Q.normalizePoint . ((Q.inv44 m) Q.!*) . Q.point
 -- 2D Based
 getImplicit3 ctx (Extrude symbObj h) =
     let

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -39,6 +39,7 @@ module Graphics.Implicit.Primitives (
                                      transform3,
                                      pack3,
                                      rotate,
+                                     transform,
                                      pack2,
                                      implicit,
                                      emptySpace,
@@ -72,6 +73,7 @@ import Graphics.Implicit.Definitions (ObjectContext, ℝ, ℝ2, ℝ3, Box2,
                                                    Circle,
                                                    Polygon,
                                                    Rotate2,
+                                                   Transform2,
                                                    Shared2
                                                   ),
                                       SymbolicObj3(
@@ -91,7 +93,7 @@ import Graphics.Implicit.Definitions (ObjectContext, ℝ, ℝ2, ℝ3, Box2,
                                      )
 import Graphics.Implicit.MathUtil   (pack)
 import Graphics.Implicit.ObjectUtil (getBox2, getBox3, getImplicit2, getImplicit3)
-import Linear (M44, V2(V2),V3(V3), axisAngle, Quaternion)
+import Linear (M33, M44, V2(V2),V3(V3), axisAngle, Quaternion)
 import Control.Lens (prism', Prism', preview, (#))
 
 -- $ 3D Primitives
@@ -445,6 +447,14 @@ pack3 (V2 dx dy) sep objs =
 
 rotate :: ℝ -> SymbolicObj2 -> SymbolicObj2
 rotate = Rotate2
+
+-- | Transform a 2D object using a 3x3 matrix representing affine transformation
+-- (OpenSCAD multmatrix)
+transform
+    :: M33 ℝ
+    -> SymbolicObj2
+    -> SymbolicObj2
+transform = Transform2
 
 -- | Attempt to pack multiple 2D objects into a fixed area.
 pack2

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -36,6 +36,7 @@ module Graphics.Implicit.Primitives (
                                      rotate3,
                                      rotateQ,
                                      rotate3V,
+                                     transform3,
                                      pack3,
                                      rotate,
                                      pack2,
@@ -78,6 +79,7 @@ import Graphics.Implicit.Definitions (ObjectContext, ℝ, ℝ2, ℝ3, Box2,
                                                    Sphere,
                                                    Cylinder,
                                                    Rotate3,
+                                                   Transform3,
                                                    Extrude,
                                                    ExtrudeM,
                                                    RotateExtrude,
@@ -89,7 +91,7 @@ import Graphics.Implicit.Definitions (ObjectContext, ℝ, ℝ2, ℝ3, Box2,
                                      )
 import Graphics.Implicit.MathUtil   (pack)
 import Graphics.Implicit.ObjectUtil (getBox2, getBox3, getImplicit2, getImplicit3)
-import Linear (V2(V2),V3(V3), axisAngle, Quaternion)
+import Linear (M44, V2(V2),V3(V3), axisAngle, Quaternion)
 import Control.Lens (prism', Prism', preview, (#))
 
 -- $ 3D Primitives
@@ -410,6 +412,14 @@ rotate3V
     -> SymbolicObj3
     -> SymbolicObj3
 rotate3V w xyz = Rotate3 $ axisAngle xyz w
+
+-- | Transform a 3D object using a 4x4 matrix representing affine transformation
+-- (OpenSCAD multmatrix)
+transform3
+    :: M44 ℝ
+    -> SymbolicObj3
+    -> SymbolicObj3
+transform3 = Transform3
 
 -- | Attempt to pack multiple 3D objects into a fixed area. The @z@ coordinate
 -- of each object is dropped, and the resulting packed objects will all be on

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -30,7 +30,8 @@ import Graphics.Implicit
       rotate3,
       rotate3V,
       transform3,
-      rotate )
+      rotate,
+      transform )
 
 import Graphics.Implicit.Definitions
     ( ExtrudeMScale(C1,C2,Fn),
@@ -74,6 +75,7 @@ instance Arbitrary SymbolicObj2 where
     then oneof small
     else oneof $
         [ rotate <$> arbitrary <*> decayArbitrary 2
+        , transform <$> arbitrary <*> decayArbitrary 2
         , Shared2 <$> arbitrary
         ] <> small
     where

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -56,7 +56,7 @@ import Test.QuickCheck
       Positive(getPositive),
       Property)
 
-import Linear (V2(V2), V3(V3), Quaternion, axisAngle)
+import Linear (V2(V2), V3(V3), V4(V4), Quaternion, axisAngle)
 
 data Insidedness = Inside | Outside | Surface
   deriving (Eq, Ord, Show, Enum, Bounded)
@@ -129,11 +129,18 @@ instance Arbitrary ℝ3 where
   shrink = genericShrink
   arbitrary = V3 <$> arbitrary <*> arbitrary <*> arbitrary
 
+instance Arbitrary a => Arbitrary (V4 a) where
+  shrink = genericShrink
+  arbitrary = V4 <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
 instance CoArbitrary ℝ2 where
   coarbitrary (V2 a b) = coarbitrary (a, b)
 
 instance CoArbitrary ℝ3 where
   coarbitrary (V3 a b c) = coarbitrary (a, b, c)
+
+instance CoArbitrary (V4 ℝ) where
+  coarbitrary (V4 a b c d) = coarbitrary (a, b, c, d)
 
 instance Arbitrary ExtrudeMScale where
   shrink = genericShrink

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -29,6 +29,7 @@ import Graphics.Implicit
       extrude,
       rotate3,
       rotate3V,
+      transform3,
       rotate )
 
 import Graphics.Implicit.Definitions
@@ -93,10 +94,11 @@ instance Arbitrary SymbolicObj3 where
     if n <= 1
     then oneof small
     else oneof $
-        [ rotate3  <$> arbitrary        <*> decayArbitrary 2
-        , rotate3V <$> arbitrary        <*> arbitrary <*> decayArbitrary 2
-        , extrude  <$> decayArbitrary 2 <*> arbitraryPos
-        , Shared3  <$> arbitrary
+        [ rotate3    <$> arbitrary        <*> decayArbitrary 2
+        , rotate3V   <$> arbitrary        <*> arbitrary        <*> decayArbitrary 2
+        , transform3 <$> arbitrary        <*> decayArbitrary 2
+        , extrude    <$> decayArbitrary 2 <*> arbitraryPos
+        , Shared3    <$> arbitrary
         ] <> small
     where
       small =

--- a/tests/Graphics/Implicit/Test/Instances.hs
+++ b/tests/Graphics/Implicit/Test/Instances.hs
@@ -123,11 +123,11 @@ instance (Arbitrary obj, Arbitrary vec, CoArbitrary vec) => Arbitrary (SharedObj
     , WithRounding <$> arbitraryPos <*> decayArbitrary 2
     ]
 
-instance Arbitrary ℝ2 where
+instance Arbitrary a => Arbitrary (V2 a) where
   shrink = genericShrink
   arbitrary = V2 <$> arbitrary <*> arbitrary
 
-instance Arbitrary ℝ3 where
+instance Arbitrary a => Arbitrary (V3 a) where
   shrink = genericShrink
   arbitrary = V3 <$> arbitrary <*> arbitrary <*> arbitrary
 
@@ -135,13 +135,13 @@ instance Arbitrary a => Arbitrary (V4 a) where
   shrink = genericShrink
   arbitrary = V4 <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
-instance CoArbitrary ℝ2 where
+instance CoArbitrary a => CoArbitrary (V2 a) where
   coarbitrary (V2 a b) = coarbitrary (a, b)
 
-instance CoArbitrary ℝ3 where
+instance CoArbitrary a => CoArbitrary (V3 a) where
   coarbitrary (V3 a b c) = coarbitrary (a, b, c)
 
-instance CoArbitrary (V4 ℝ) where
+instance CoArbitrary a => CoArbitrary (V4 a) where
   coarbitrary (V4 a b c d) = coarbitrary (a, b, c, d)
 
 instance Arbitrary ExtrudeMScale where

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -8,7 +8,7 @@
 
 module ImplicitSpec (spec) where
 
-import Prelude (fmap, pure, negate, (+), String,  Show, Monoid, mempty, (*), (<>), (-), (/=), ($), (.), pi, id)
+import Prelude (Fractional, not, fmap, pure, negate, (+), String,  Show, Monoid, mempty, (*), (/), (<>), (-), (/=), ($), (.), pi, id)
 import Test.Hspec (xit, SpecWith, describe, Spec)
 import Graphics.Implicit
     ( difference,
@@ -33,7 +33,7 @@ import Test.QuickCheck
       forAll)
 import Data.Foldable ( for_ )
 import Test.Hspec.QuickCheck (prop)
-import Linear ( V3(V3), (^*) )
+import Linear ( V3(V3), (^*) , Epsilon(nearZero))
 import Graphics.Implicit (unionR)
 import Graphics.Implicit (intersectR)
 import Graphics.Implicit (extrude)
@@ -79,6 +79,8 @@ type TestInfrastructure obj vec test outcome =
   , Show vec
   , Arbitrary obj
   , Arbitrary vec
+  , Epsilon vec
+  , Fractional vec
   )
 
 ------------------------------------------------------------------------------
@@ -135,13 +137,10 @@ inverseSpec = describe "inverses" $ do
     translate @obj xyz . translate (negate xyz)
       =~= id
 
-  -- TODO(sandy): there should be a scale inverse here, but it's a hard thing
-  -- to quantify over due to our lack of functors for R2 and R3.
-
-  -- -- prop "scale inverse" $
-  -- --   forAll (arbitrary `suchThat` (/= 0)) $ \xyz ->
-  -- --     scale @obj xyz . scale (invert xyz)
-  -- --       =~= id
+  prop "scale inverse" $
+    forAll (arbitrary `suchThat` (not . nearZero)) $ \xyz ->
+      scale @obj xyz . scale (1 / xyz)
+      =~= id
 
 ------------------------------------------------------------------------------
 -- Proofs that 'fullSpace' is an annhilative element with respect to union.

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -228,6 +228,9 @@ misc3dSpec = describe "misc 3d tests" $ do
   prop "cylinder with negative height is a flipped cylinder with positive height" $ \r1 r2 h ->
     cylinder2 r1 r2 h =~= mirror (V3 0 0 1) (cylinder2 r1 r2 (-h))
 
+  prop "negative scale in X is mirror about Y plane" $
+    scale @SymbolicObj3 (V3 (-1) 1 1) =~= mirror (V3 1 0 0)
+
 ------------------------------------------------------------------------------
 -- Misc identity proofs that should hold for all symbolic objects.
 identitySpec

--- a/tests/ImplicitSpec.hs
+++ b/tests/ImplicitSpec.hs
@@ -13,6 +13,7 @@ import Test.Hspec (xit, SpecWith, describe, Spec)
 import Graphics.Implicit
     ( difference,
       rotate,
+      transform,
       rotate3,
       rotate3V,
       transform3,
@@ -34,7 +35,7 @@ import Test.QuickCheck
       forAll)
 import Data.Foldable ( for_ )
 import Test.Hspec.QuickCheck (prop)
-import Linear ( V3(V3), V4(V4), (^*) , Epsilon(nearZero))
+import Linear (V2(V2), V3(V3), V4(V4), (^*) , Epsilon(nearZero))
 import qualified Linear
 import Graphics.Implicit (unionR)
 import Graphics.Implicit (intersectR)
@@ -57,6 +58,7 @@ spec = do
     inverseSpec      @SymbolicObj2
     annihilationSpec @SymbolicObj2
     rotation2dSpec
+    transform2dSpec
 
   describe "symbolic obj 3" $ do
     idempotenceSpec  @SymbolicObj3
@@ -182,6 +184,23 @@ rotation2dSpec = describe "2d rotation" $ do
   prop "empty idempotent wrt rotate" $ \rads ->
     rotate rads emptySpace
       =~= emptySpace
+
+------------------------------------------------------------------------------
+-- Misc proofs regarding 3d transformation.
+transform2dSpec :: Spec
+transform2dSpec = describe "2d transform" $ do
+  prop "identity" $
+    transform Linear.identity
+    =~= id
+
+  prop "same as translation" $ \tr@(V2 x y) ->
+    transform
+      (V3
+        (V3 1 0 x)
+        (V3 0 1 y)
+        (V3 0 0 1)
+      )
+    =~= translate tr
 
 ------------------------------------------------------------------------------
 -- Misc proofs regarding 3d rotation.


### PR DESCRIPTION
Adds `Transform3` primitive which allows us to implement `multmatrix` requested in #397.

Also adds some other tidbits like scaling inverse property and negative scaling property.

~`ExtOpenScad` support not yet implemented, marking as draft.~