### PR TITLE
Fix pending undefined test

### DIFF
--- a/Graphics/Implicit/ExtOpenScad/Definitions.hs
+++ b/Graphics/Implicit/ExtOpenScad/Definitions.hs
@@ -153,6 +153,7 @@ instance Eq OVal where
     (ONum  a) == (ONum  b) = a == b
     (OList a) == (OList b) = and $ zipWith (==) a b
     (OString a) == (OString b) = a == b
+    OUndefined == OUndefined = True
     _ == _ = False
 
 instance Show OVal where

--- a/tests/ParserSpec/Expr.hs
+++ b/tests/ParserSpec/Expr.hs
@@ -15,7 +15,7 @@ module ParserSpec.Expr (exprSpec) where
 import Prelude (Bool(True, False), ($))
 
 -- Hspec, for writing specs.
-import Test.Hspec (describe, Expectation, Spec, it, pendingWith, specify)
+import Test.Hspec (describe, Spec, it, specify)
 
 import Data.Text.Lazy (Text)
 
@@ -38,9 +38,6 @@ pattern Var :: Text -> Expr
 pattern Var  s = GIED.Var  (Symbol s)
 pattern Name :: Text -> GIED.Pattern
 pattern Name n = GIED.Name (Symbol n)
-
-undefinedIssue :: Expectation -> Expectation
-undefinedIssue _ = pendingWith "this errors, but the expecting is equal to the recieved. huh?"
 
 logicalSpec :: Spec
 logicalSpec = do
@@ -90,7 +87,7 @@ literalSpec = do
     it "accepts true" $ "true" --> bool True
     it "accepts false" $ "false" --> bool False
   describe "undefined" $
-    it "accepts undef" $ undefinedIssue $ "undef" --> undefined
+    it "accepts undef" $ "undef" --> undefined
 
 letBindingSpec :: Spec
 letBindingSpec = do


### PR DESCRIPTION
Was disabled due to

```
  1) expression parsing, literals, undefined, accepts undef
       expected: Right (LitE Undefined)
        but got: Right (LitE Undefined)
```

caused by custom `Eq OVal` where `OUndefined == OUndefined = False`
which is now corrected to `OUndefined == OUndefined = True`.

Tested vs openscad where `if(undef == undef) echo("YES");` is allowed
and works as expected.