### PR TITLE
Splitting up StateC and CompState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,4 @@
   * Rotate now internally uses quaternions [#314](https://github.com/Haskell-Things/ImplicitCAD/pull/314)
   * Fixes to triangle generation [#355](https://github.com/Haskell-Things/ImplicitCAD/pull/355) and [#375](https://github.com/Haskell-Things/ImplicitCAD/pull/375)
   * ExtOpenSCAD vector addition [#408](https://github.com/Haskell-Things/ImplicitCAD/pull/408)
+  * Migrating StateC and StateE to a ReaderT/WriterT/StateT transformer stack [#432](https://github.com/Haskell-Things/ImplicitCAD/pull/432)

--- a/Graphics/Implicit/ExtOpenScad/Definitions.hs
+++ b/Graphics/Implicit/ExtOpenScad/Definitions.hs
@@ -30,7 +30,7 @@ module Graphics.Implicit.ExtOpenScad.Definitions (ArgParser(AP, APTest, APBranch
                                                   VarLookup(VarLookup),
                                                   Message(Message),
                                                   MessageType(TextOut, Warning, Error, SyntaxError, Compatibility, Unimplemented),
-                                                       ScadOpts(ScadOpts, openScadCompatibility, importsAllowed),
+                                                  ScadOpts(ScadOpts, openScadCompatibility, importsAllowed),
                                                   lookupVarIn,
                                                   varUnion,
                                                   runImplicitCadM,

--- a/Graphics/Implicit/ExtOpenScad/Eval/Expr.hs
+++ b/Graphics/Implicit/ExtOpenScad/Eval/Expr.hs
@@ -12,7 +12,7 @@
 
 module Graphics.Implicit.ExtOpenScad.Eval.Expr (evalExpr, rawRunExpr, matchPat, StateE, ExprState(ExprState), messages, addMessage) where
 
-import Prelude (String, Maybe(Just, Nothing), ($), fmap, pure, zip, (!!), const, (<>), foldr, foldMap, (.), (<$>), traverse)
+import Prelude (String, Maybe(Just, Nothing), ($), pure, zip, (!!), const, (<>), foldr, foldMap, (.), (<$>), traverse)
 
 import Graphics.Implicit.ExtOpenScad.Definitions (
                                                   Pattern(Name, ListP, Wild),
@@ -121,13 +121,13 @@ evalExpr' (LitE  val) = pure $ const val
 -- Evaluate a list of expressions.
 evalExpr' (ListE exprs) = do
     valFuncs <- traverse evalExpr' exprs
-    pure $ \s -> OList $ ($s) <$> valFuncs
+    pure $ \s -> OList $ ($ s) <$> valFuncs
 
 -- Evaluate application of a function.
 evalExpr' (fexpr :$ argExprs) = do
     fValFunc <- evalExpr' fexpr
     argValFuncs <- traverse evalExpr' argExprs
-    pure $ \s -> app (fValFunc s) (fmap ($s) argValFuncs)
+    pure $ \s -> app (fValFunc s) (($ s) <$> argValFuncs)
         where
             app f l = case (getErrors f, getErrors $ OList l) of
                 (Nothing, Nothing) -> app' f l

--- a/Graphics/Implicit/ExtOpenScad/Eval/Expr.hs
+++ b/Graphics/Implicit/ExtOpenScad/Eval/Expr.hs
@@ -119,7 +119,7 @@ rawRunExpr pos vars expr = do
   let
     input = Input vars pos
     initState = ExprState []
-    (valf, messages, _) = runStateE input initState (evalExpr' expr) 
+    (valf, messages, _) = runStateE input initState (evalExpr' expr)
   (valf [], messages)
 
 -- The expression evaluators.

--- a/Graphics/Implicit/ExtOpenScad/Util/StateC.hs
+++ b/Graphics/Implicit/ExtOpenScad/Util/StateC.hs
@@ -7,7 +7,7 @@ module Graphics.Implicit.ExtOpenScad.Util.StateC (addMessage, getVarLookup, modi
 
 import Prelude(FilePath, Maybe, ($), (<>), pure)
 
-import Graphics.Implicit.ExtOpenScad.Definitions(VarLookup(VarLookup), OVal, Symbol, SourcePosition, Message(Message), MessageType(Error, Warning), ScadOpts, StateC, CompState(scadVars, oVals, sourceDir, messages, scadOpts))
+import Graphics.Implicit.ExtOpenScad.Definitions(VarLookup(VarLookup), OVal, Symbol, SourcePosition, Message(Message), MessageType(Error, Warning), ScadOpts, StateC, CompState(scadVars, oVals, sourceDir), ImplicitCadM)
 
 import Data.Map (lookup)
 
@@ -16,6 +16,8 @@ import Data.Text.Lazy (Text)
 import Control.Monad.State (modify, gets)
 
 import System.FilePath((</>))
+import Control.Monad.Writer (tell)
+import Control.Monad.Reader.Class (ask)
 
 getVarLookup :: StateC VarLookup
 getVarLookup = gets scadVars
@@ -56,8 +58,9 @@ getRelPath relPath = do
     path <- getPath
     pure $ path </> relPath
 
-addMesg :: Message -> StateC ()
-addMesg m = modify $ \c -> c { messages = messages c <> pure m }
+-- Add a single message to the list of messages being returned
+addMesg :: Message -> ImplicitCadM ()
+addMesg m = tell [m]
 
 addMessage :: MessageType -> SourcePosition -> Text -> StateC ()
 addMessage mtype pos text = addMesg $ Message mtype pos text
@@ -70,6 +73,6 @@ warnC :: SourcePosition -> Text -> StateC ()
 warnC = addMessage Warning
 {-# INLINABLE warnC #-}
 
-scadOptions :: StateC ScadOpts
-scadOptions = gets scadOpts
-
+-- Get the ScadOpts from the Reader in ImplicitCadM
+scadOptions :: ImplicitCadM ScadOpts
+scadOptions = ask

--- a/Graphics/Implicit/ExtOpenScad/Util/StateC.hs
+++ b/Graphics/Implicit/ExtOpenScad/Util/StateC.hs
@@ -7,7 +7,7 @@ module Graphics.Implicit.ExtOpenScad.Util.StateC (addMessage, getVarLookup, modi
 
 import Prelude(FilePath, Maybe, ($), (<>), pure)
 
-import Graphics.Implicit.ExtOpenScad.Definitions(VarLookup(VarLookup), OVal, Symbol, SourcePosition, Message(Message), MessageType(Error, Warning), ScadOpts, StateC, CompState(scadVars, oVals, sourceDir), ImplicitCadM)
+import Graphics.Implicit.ExtOpenScad.Definitions(VarLookup(VarLookup), OVal, Symbol, SourcePosition, Message(Message), MessageType(Error, Warning), ScadOpts, StateC, CompState(scadVars, oVals, sourceDir))
 
 import Data.Map (lookup)
 
@@ -59,7 +59,7 @@ getRelPath relPath = do
     pure $ path </> relPath
 
 -- Add a single message to the list of messages being returned
-addMesg :: Message -> ImplicitCadM ()
+addMesg :: Message -> StateC ()
 addMesg m = tell [m]
 
 addMessage :: MessageType -> SourcePosition -> Text -> StateC ()
@@ -74,5 +74,5 @@ warnC = addMessage Warning
 {-# INLINABLE warnC #-}
 
 -- Get the ScadOpts from the Reader in ImplicitCadM
-scadOptions :: ImplicitCadM ScadOpts
+scadOptions :: StateC ScadOpts
 scadOptions = ask


### PR DESCRIPTION
Splitting StateC into a Reader/Writer/State transformer, as scadOpts was only ever read from, and messages was only ever written to or returned at the end of a processing batch.

This also involved splitting these values out of CompState as they did not need to both readable and writable.

Setting up some constraint types to allow easier use of the new monad transformer in code that doesn't need to know the exact structure of the transformer, just what it can do.