### PR TITLE
Adding basic support for `rands` and `lookup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   * `rotateExtrude` angle `a` parameter renamed to `angle` to match OpenSCAD [#259](https://github.com/Haskell-Things/ImplicitCAD/pull/259)
   * Added `mirror` support [#300](https://github.com/Haskell-Things/ImplicitCAD/pull/300)
   * Added `multmatrix` support [#410](https://github.com/Haskell-Things/ImplicitCAD/pull/410)
+  * Added `rands` and `lookup` support [#433](https://github.com/Haskell-Things/ImplicitCAD/pull/433)
 
 * Other changes
   * Fixed the ExtOpenSCAD lexer bug where newlines were part of identifiers [#256](https://github.com/Haskell-Things/ImplicitCAD/pull/256)
@@ -44,3 +45,4 @@
   * Rotate now internally uses quaternions [#314](https://github.com/Haskell-Things/ImplicitCAD/pull/314)
   * Fixes to triangle generation [#355](https://github.com/Haskell-Things/ImplicitCAD/pull/355) and [#375](https://github.com/Haskell-Things/ImplicitCAD/pull/375)
   * ExtOpenSCAD vector addition [#408](https://github.com/Haskell-Things/ImplicitCAD/pull/408)
+  * Migrating StateC and StateE to a ReaderT/WriterT/StateT transformer stack, rather than being just StateT. [#432](https://github.com/Haskell-Things/ImplicitCAD/pull/432)

--- a/Graphics/Implicit/ExtOpenScad/Default.hs
+++ b/Graphics/Implicit/ExtOpenScad/Default.hs
@@ -29,15 +29,17 @@ import Data.Int (Int64)
 
 import Data.Map (Map, fromList, insert)
 
-import Data.List (genericIndex, genericLength)
+import Data.List (genericIndex, genericLength, find)
 
-import Data.Foldable (for_)
+import Data.Foldable (for_, foldr)
 
 import qualified Data.Text.Lazy as TL (index)
 
 import Data.Text.Lazy (Text, intercalate, unpack, pack, length, singleton)
 import Control.Monad (replicateM)
 import System.Random (randomRIO)
+import Data.Maybe (maybe)
+import Data.Tuple (snd)
 
 defaultObjects :: Bool -> VarLookup
 defaultObjects withCSG = VarLookup $ fromList $
@@ -48,9 +50,6 @@ defaultObjects withCSG = VarLookup $ fromList $
     <> defaultPolymorphicFunctions
     <> (if withCSG then primitiveModules else [])
     <> varArgModules
-
--- FIXME: Missing standard ones(which standard?):
--- rand, lookup,
 
 defaultConstants :: [(Symbol, OVal)]
 defaultConstants = (\(a,b) -> (a, toOObj (b :: ℝ))) <$>
@@ -184,10 +183,54 @@ defaultPolymorphicFunctions =
         (Symbol "<>", concatenate),
         (Symbol "len", toOObj olength),
         (Symbol "str", toOObj (pack.show :: OVal -> Text)),
-        (Symbol "rands", toOObj rands)
+        (Symbol "rands", toOObj rands),
+        (Symbol "lookup", toOObj lookup)
     ] where
 
         -- Some key functions are written as OVals in optimizations attempts
+
+        -- Lookup a value from the given table, or linearly interpolate a value from
+        -- the nearest entries. Lookups for keys that fall outside the bounds of the
+        -- table will be given the value of the nearest table entry.
+        -- TODO, a binary tree would be faster for large tables, but I'm not bothering
+        -- until we have a good reason to do so, i.e. we see a need for it.
+        lookup :: ℝ -> [(ℝ, ℝ)] -> OVal
+        lookup key table =
+            let
+                -- Find the next lower value, and the next upper value from key
+                search op op' = foldr
+                    (\t@(k, _) -> maybe
+                        ( if k `op` key
+                          then pure t
+                          else Nothing
+                        )
+                        $ \t'@(k', _) -> pure $
+                            if k `op'` k' && k `op` key
+                            then t
+                            else t'
+                    )
+                    Nothing
+                    table
+                lower = search (<) (>)
+                upper = search (>) (<)
+                -- Interpolate linearly
+                -- Take the extremes if the key is out of bounds.
+                -- Undefined for empty tables, as the docs don't say what it should be.
+                -- https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Mathematical_Functions#lookup
+                interpolated = case (lower, upper) of
+                    (Just (lk, lv), Just (uk, uv)) ->
+                        -- calculate the linear slope of the graph
+                        let scale = (uv - lv) / (uk - lk)
+                        -- Use the lower value as the base, and add on the
+                        -- required amount of scaling
+                        in ONum $ lv + ((key - lk) * scale)
+                    (Nothing, Just (_, uv)) -> ONum uv
+                    (Just (_, lv), Nothing) -> ONum lv
+                    (Nothing, Nothing)      -> OUndefined
+            in maybe
+                interpolated
+                (ONum . snd)
+                $ find (\(k, _) -> k == key) table
 
         rands :: ℝ -> ℝ -> ℝ -> IO OVal
         rands minR maxR count = do

--- a/Graphics/Implicit/ExtOpenScad/Definitions.hs
+++ b/Graphics/Implicit/ExtOpenScad/Definitions.hs
@@ -14,7 +14,7 @@ module Graphics.Implicit.ExtOpenScad.Definitions (ArgParser(AP, APTest, APBranch
                                                   Expr(LitE, Var, ListE, LamE, (:$)),
                                                   StatementI(StatementI),
                                                   Statement(DoNothing, NewModule, Include, If, ModuleCall, (:=)),
-                                                  OVal(ONum, OBool, OString, OList, OFunc, OUndefined, OUModule, ONModule, OVargsModule, OError, OObj2, OObj3),
+                                                  OVal(OIO, ONum, OBool, OString, OList, OFunc, OUndefined, OUModule, ONModule, OVargsModule, OError, OObj2, OObj3),
                                                   TestInvariant(EulerCharacteristic),
                                                   SourcePosition(SourcePosition),
                                                   StateC,
@@ -140,6 +140,7 @@ data OVal = OUndefined
          | OList [OVal]
          | OString Text
          | OFunc (OVal -> OVal)
+         | OIO (IO OVal)
          -- Name, arguments, argument parsers.
          | OUModule Symbol (Maybe [(Symbol, Bool)]) (VarLookup -> ArgParser (StateC [OVal]))
          -- Name, implementation, arguments, whether the module accepts/requires a suite.
@@ -163,6 +164,7 @@ instance Show OVal where
     show (OList l) = show l
     show (OString s) = show s
     show (OFunc _) = "<function>"
+    show (OIO _) = "<IO>"
     show (OUModule (Symbol name) arguments _) = "module " <> unpack name <> " (" <> unpack (intercalate ", " (showArg <$> fromMaybe [] arguments)) <> ") {}"
       where
         showArg :: (Symbol, Bool) -> Text

--- a/implicit.cabal
+++ b/implicit.cabal
@@ -92,7 +92,8 @@ Library
                   mtl,
                   linear,
                   show-combinators,
-                  lens
+                  lens,
+                  random
 
 
     Exposed-modules:

--- a/tests/ExecSpec/Expr.hs
+++ b/tests/ExecSpec/Expr.hs
@@ -18,7 +18,7 @@ import Graphics.Implicit.Definitions (ℝ)
 import ExecSpec.Util ((-->), num, list, vect)
 
 import Graphics.Implicit.ExtOpenScad.Eval.Constant (runExpr)
-import Graphics.Implicit.ExtOpenScad.Definitions (OVal(OIO, OList, ONum))
+import Graphics.Implicit.ExtOpenScad.Definitions (OVal(OIO, OList, ONum, OUndefined))
 
 -- Default all numbers in this file to being of the type ImplicitCAD uses for values.
 default (ℝ)
@@ -78,3 +78,18 @@ exprExec = do
           ONum n <- m
           shouldSatisfy n $ \n' -> 1 <= n' && n' <= 2
         o -> expectationFailure $ "Not an OIO: " <> show o
+  describe "lookup" $ do
+    it "Gets a value from a table" $ do
+      "lookup(1, [[0, 0], [1, 1], [2, 2]])" --> num 1
+    it "Interpolates values from a table" $ do
+      "lookup(1, [[0, 0], [2, 2]])" --> num 1
+      "lookup(7, [[0, 0], [5, 50], [10, 100], [11, 0]])" --> num 70
+      "lookup(10.5, [[0, 0], [5, 50], [10, 100], [11, 0]])" --> num 50
+    it "Gets an upper extreme from a table" $ do
+      "lookup(10, [[0, 0], [1, 1], [2, 2]])" --> num 2
+    it "Gets an lower extreme from a table" $ do
+      "lookup(0, [[1, 1], [2, 2]])" --> num 1
+    it "Gets an nothing from a table" $ do
+      "lookup(0, [])" --> OUndefined
+    it "Handles embedded statements" $ do
+      "lookup(0+1, [[0*2, 0], [1+1, 4/2]])" --> num 1

--- a/tests/ExecSpec/Expr.hs
+++ b/tests/ExecSpec/Expr.hs
@@ -6,7 +6,7 @@
 module ExecSpec.Expr (exprExec) where
 
 -- Be explicit about what we import.
-import Prelude (($), pure, (==), length, Bool (False), (<=), (&&), (<>), show)
+import Prelude (($), (==), length, Bool (False), (<=), (&&), (<>), show)
 
 -- Hspec, for writing specs.
 import Test.Hspec (describe, Spec, it, shouldSatisfy, expectationFailure)
@@ -15,7 +15,7 @@ import Test.Hspec (describe, Spec, it, shouldSatisfy, expectationFailure)
 import Graphics.Implicit.Definitions (ℝ)
 
 -- Our utility library, for making these tests easier to read.
-import ExecSpec.Util ((-->), num, list, vect, io)
+import ExecSpec.Util ((-->), num, list, vect)
 
 import Graphics.Implicit.ExtOpenScad.Eval.Constant (runExpr)
 import Graphics.Implicit.ExtOpenScad.Definitions (OVal(OIO, OList, ONum))

--- a/tests/ExecSpec/Expr.hs
+++ b/tests/ExecSpec/Expr.hs
@@ -49,32 +49,32 @@ exprExec = do
       case runExpr "rands(1,2,1)" False of
         (OIO m, _) -> do
           OList l <- m
-          shouldSatisfy l $ \l -> length l == 1
+          shouldSatisfy l $ \l' -> length l' == 1
         _ -> expectationFailure "Not an OIO"
       case runExpr "rands(1,2,10)" False of
         (OIO m, _) -> do
           OList l <- m
-          shouldSatisfy l $ \l -> length l == 10
+          shouldSatisfy l $ \l' -> length l' == 10
         _ -> expectationFailure "Not an OIO"
       case runExpr "rands(1,2,0)" False of
         (OIO m, _) -> do
           OList l <- m
-          shouldSatisfy l $ \l -> length l == 0
+          shouldSatisfy l $ \l' -> length l' == 0
         _ -> expectationFailure "Not an OIO"
       case runExpr "rands(1,1,1)" False of
         (OIO m, _) -> do
           OList l <- m
-          shouldSatisfy l $ \l ->
-            length l == 1 &&
-            l == [num 1]
+          shouldSatisfy l $ \l' ->
+            length l' == 1 &&
+            l' == [num 1]
         _ -> expectationFailure "Not an OIO"
       case runExpr "rands(1,2,1)[0]" False of
-        (OIO m, _) -> do 
+        (OIO m, _) -> do
           ONum n <- m
-          shouldSatisfy n $ \n' -> 1 <= n' && n' <= 2            
+          shouldSatisfy n $ \n' -> 1 <= n' && n' <= 2
         o -> expectationFailure $ "Not an OIO: " <> show o
       case runExpr "rands(1,2,2)[0+1]" False of
-        (OIO m, _) -> do 
+        (OIO m, _) -> do
           ONum n <- m
-          shouldSatisfy n $ \n' -> 1 <= n' && n' <= 2            
+          shouldSatisfy n $ \n' -> 1 <= n' && n' <= 2
         o -> expectationFailure $ "Not an OIO: " <> show o

--- a/tests/ExecSpec/Util.hs
+++ b/tests/ExecSpec/Util.hs
@@ -10,16 +10,17 @@ module ExecSpec.Util
        , num
        , list
        , vect
+       , io
        ) where
 
 -- be explicit about where we get things from.
-import Prelude (String, Bool(False), map, (.))
+import Prelude (String, Bool(False), map, (.), IO)
 
 -- The datatype of positions in our world.
 import Graphics.Implicit.Definitions (ℝ)
 
 -- Expressions, symbols, and values in the OpenScad language.
-import Graphics.Implicit.ExtOpenScad.Definitions (OVal(ONum, OList))
+import Graphics.Implicit.ExtOpenScad.Definitions (OVal(ONum, OList, OIO))
 
 import Graphics.Implicit.ExtOpenScad.Eval.Constant (runExpr)
 
@@ -41,3 +42,6 @@ list = OList
 
 vect :: [ℝ] -> OVal
 vect =  list . map num
+
+io :: IO OVal -> OVal
+io = OIO


### PR DESCRIPTION
This is addressing https://github.com/Haskell-Things/ImplicitCAD/issues/213

Adding basic support for the rands function, without support for seeding the rng explicitly. It is using the global prng.

This also adds the `OIO` OVal type, supporting IO actions. This is necessary for using the global rng.

Adding support for indexing into OIO values.

Adding some expression tests for `rands`, checking that values are in the desired range and count.