### PR TITLE
Fixing exponent operator precedence.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Other changes
   * Migrating StateC and StateE to a ReaderT/WriterT/StateT transformer stack, rather than being just StateT. [#432](https://github.com/Haskell-Things/ImplicitCAD/pull/432)
+  * Fixing exponent operator precedence. [#428](https://github.com/Haskell-Things/ImplicitCAD/issues/428)
 
 # Version [0.4.0.0](https://github.com/Haskell-Things/ImplicitCAD/compare/v0.3.0.0...v0.4.0.0) (2022-06-06)
 

--- a/Graphics/Implicit/ExtOpenScad/Parser/Expr.hs
+++ b/Graphics/Implicit/ExtOpenScad/Parser/Expr.hs
@@ -69,10 +69,10 @@ expr0 = foldr ($) nonAssociativeExpr levels
           chainl1 higher $ binaryOperation . singleton <$> oneOf "+-" <* whiteSpace
       , \higher -> -- string/list concatenation operator (++). This is not available in OpenSCAD.
           chainl1 higher $ binaryOperation <$> matchCAT
-      , \higher -> -- exponent operator (^). This is not available in OpenSCAD.
-          chainr1 higher $ binaryOperation . singleton <$> matchEXP
       , \higher -> -- multiplication (*), division (/), and modulus (%) operators
           chainl1 higher $ binaryOperation . singleton <$> oneOf "*/%" <* whiteSpace
+      , \higher -> -- exponent operator (^). This is not available in OpenSCAD.
+          chainr1 higher $ binaryOperation . singleton <$> matchEXP
       , \higher ->
           fix $ \self -> -- unary ! operator. OpenSCAD's YACC parser puts '!' at the same level of precedence as '-' and '+'.
                   do

--- a/tests/ExecSpec/Expr.hs
+++ b/tests/ExecSpec/Expr.hs
@@ -93,3 +93,9 @@ exprExec = do
       "lookup(0, [])" --> OUndefined
     it "Handles embedded statements" $ do
       "lookup(0+1, [[0*2, 0], [1+1, 4/2]])" --> num 1
+  describe "operator precedence" $ do
+    -- https://github.com/Haskell-Things/ImplicitCAD/issues/428
+    it "Evaluates exponents correctly" $ do
+      "2*3^2" --> num 18
+      "-2^2" --> num 4
+      "-(2^2)" --> num (-4)


### PR DESCRIPTION
Making exponent calls have a higher precedence than multiplication/division. Leaving unary sign precedence as-is.