### PR TITLE
Adding primitives for `cone`, `torus`, and `ellipsoid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 * ExtOpenScad interface changes
   * Added `rands` and `lookup` support [#433](https://github.com/Haskell-Things/ImplicitCAD/pull/433)
+  * Added several primitives
+    * `cone(r, h, center)`
+    * `torus(r1, r2)`
+    * `ellipsoid(a, b, c)`
+
+* Haskell interface changes
+  * Added matching primitives for `cone`, `torus`, and `ellipsoid`
 
 * Other changes
   * Migrating StateC and StateE to a ReaderT/WriterT/StateT transformer stack, rather than being just StateT. [#432](https://github.com/Haskell-Things/ImplicitCAD/pull/432)

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -30,6 +30,9 @@ module Graphics.Implicit.Primitives (
                                      circle,
                                      cylinder,
                                      cylinder2,
+                                     cone,
+                                     torus,
+                                     ellipsoid,
                                      square, rect,
                                      polygon,
                                      rotateExtrude,
@@ -50,7 +53,7 @@ module Graphics.Implicit.Primitives (
                                      Object
                                     ) where
 
-import Prelude(Applicative, Eq, Num, abs, (<), otherwise, id, Num, (+), (-), (*), (/), (.), negate, Bool(True, False), Maybe(Just, Nothing), Either, fmap, ($))
+import Prelude(Applicative, Eq, Num, abs, (<), otherwise, id, Num, (+), (-), (*), (/), (.), negate, Bool(True, False), Maybe(Just, Nothing), Either, fmap, ($), (**), sqrt)
 
 import Graphics.Implicit.Definitions (ObjectContext, ℝ, ℝ2, ℝ3, Box2,
                                       SharedObj(Empty,
@@ -139,6 +142,24 @@ cylinder ::
     -> SymbolicObj3     -- ^ Resulting cylinder
 
 cylinder r = cylinder2 r r
+
+cone ::
+    ℝ                   -- ^ Radius of the cylinder
+    -> ℝ                -- ^ Height of the cylinder
+    -> SymbolicObj3     -- ^ Resulting cylinder
+cone r h = cylinder2 0 r h
+
+torus :: ℝ -> ℝ -> SymbolicObj3 -- Major radius, minor radius
+torus r1 r2 = implicit
+    (\(V3 x y z) -> let a = (sqrt (x**2 + y**2) - r1) in a**2 + z**2 - r2**2)
+    (V3 (-r) (-r) (-r2), V3 r r r2)
+    where
+        r = r1 + r2
+
+ellipsoid :: ℝ -> ℝ -> ℝ -> SymbolicObj3 -- a, b, c
+ellipsoid a b c = implicit
+    (\(V3 x y z) -> (x**2/a**2) + (y**2/b**2) + (z**2/c**2) - 1)
+    (V3 (-a) (-b) (-c), V3 a b c)
 
 -- $ 2D Primitives
 

--- a/tests/GoldenSpec/Spec.hs
+++ b/tests/GoldenSpec/Spec.hs
@@ -8,6 +8,7 @@ import GoldenSpec.Util (golden, goldenAllFormats)
 import Graphics.Implicit
 import Prelude
 import Test.Hspec ( describe, Spec )
+import Graphics.Implicit.Primitives (torus, ellipsoid, cone)
 
 default (Int)
 
@@ -163,3 +164,9 @@ spec = describe "golden tests" $ do
             cylinder 10 80
       ]
 
+  golden "torusEllipsoidCone" 2 $
+    union
+      [ torus 40 15
+      , ellipsoid 10 15 20
+      , translate (V3 0 0 25) $ cone 20 20
+      ]


### PR DESCRIPTION
This is adding some primitives as suggested by https://github.com/Haskell-Things/ImplicitCAD/issues/341

- Adding the above functions to both extopenscad and haskell interfaces.
- Adding a golden test file that uses these primitives.
