### PR TITLE
Issue #450. Making torus and ellipsoid primitive objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Other changes
   * Fixing `shell` so that it doesn't increase the outside dimentions of objects.
   * Fixing an issue with bounding boxes for infinite functions. [#412](https://github.com/Haskell-Things/ImplicitCAD/issues/412)
+  * Making `torus` and `ellipsoid` primitive objects, rather than being defined implicitly. [#450](https://github.com/Haskell-Things/ImplicitCAD/issues/450)
 
 # Version [0.4.1.0](https://github.com/Haskell-Things/ImplicitCAD/compare/v0.4.0.0...v0.4.1.0) (2023-12-18)
 

--- a/Graphics/Implicit/Canon.hs
+++ b/Graphics/Implicit/Canon.hs
@@ -91,6 +91,8 @@ import Graphics.Implicit.Definitions
       , Shared3
       , Sphere
       , Transform3
+      , Torus
+      , Ellipsoid
       )
   , hasZeroComponent
   )
@@ -171,6 +173,8 @@ fmapObj3
 fmapObj3 f _ _ (Cube v) = f $ Cube v
 fmapObj3 f _ _ (Sphere r) = f $ Sphere r
 fmapObj3 f _ _ (Cylinder r1 r2 h) = f $ Cylinder r1 r2 h
+fmapObj3 f _ _ (Torus r1 r2) = f $ Torus r1 r2
+fmapObj3 f _ _ (Ellipsoid a b c) = f $ Ellipsoid a b c
 fmapObj3 f g s (Rotate3 q o) = f $ Rotate3 q (fmapObj3 f g s o)
 fmapObj3 f g s (Transform3 m o) = f $ Transform3 m (fmapObj3 f g s o)
 fmapObj3 f g s (Extrude o2 h) = f $ Extrude (fmapObj2 g f s o2) h
@@ -225,6 +229,8 @@ instance EqObj SymbolicObj2 where
 instance EqObj SymbolicObj3 where
   Cube a =^= Cube b = a == b
   Sphere a =^= Sphere b = a == b
+  Torus a1 a2 =^= Torus b1 b2 = a1 == b1 && a2 == b2
+  Ellipsoid a1 b1 c1 =^= Ellipsoid a2 b2 c2 = a1 == a2 && b1 == b2 && c1 == c2
   Cylinder r1a r2a ha =^= Cylinder r1b r2b hb = r1a == r1b && r2a == r2b && ha == hb
   Rotate3 x a =^= Rotate3 y b = x == y && a =^= b
   Transform3 x a =^= Transform3 y b = x == y && a =^= b
@@ -300,6 +306,10 @@ canon3 (Cube v) | hasZeroComponent v = emptySpace
 canon3 (Sphere 0) = emptySpace
 canon3 (Cylinder 0 _ _) = emptySpace
 canon3 (Extrude _o2 0) = emptySpace
+canon3 (Torus _ 0) = emptySpace
+canon3 (Ellipsoid 0 _ _) = emptySpace
+canon3 (Ellipsoid _ 0 _) = emptySpace
+canon3 (Ellipsoid _ _ 0) = emptySpace
 canon3 (Rotate3 0 o) = o
 canon3 (RotateExtrude 0 _t _r _o) = emptySpace
 canon3 (RotateExtrude _theta _t _r (Shared Empty)) = emptySpace

--- a/Graphics/Implicit/Definitions.hs
+++ b/Graphics/Implicit/Definitions.hs
@@ -58,6 +58,8 @@ module Graphics.Implicit.Definitions (
         Cylinder,
         Rotate3,
         Transform3,
+        Torus,
+        Ellipsoid,
         Extrude,
         ExtrudeM,
         ExtrudeOnEdgeOf,
@@ -324,6 +326,8 @@ data SymbolicObj3 =
       Cube ℝ3 -- rounding, size.
     | Sphere ℝ -- radius
     | Cylinder ℝ ℝ ℝ --
+    | Torus ℝ ℝ
+    | Ellipsoid ℝ ℝ ℝ
     -- Simple transforms
     | Rotate3 (Quaternion ℝ) SymbolicObj3
     | Transform3 (M44 ℝ) SymbolicObj3
@@ -367,6 +371,8 @@ instance Show SymbolicObj3 where
     ExtrudeOnEdgeOf s s1 ->
       showCon "extrudeOnEdgeOf" @| s @| s1
     Shared3 s -> flip showsPrec s
+    Torus r1 r2 -> showCon "torus" @| r1 @| r2
+    Ellipsoid a b c -> showCon "ellipsoid" @| a @| b @| c
 
 infixl 2 @||
 ------------------------------------------------------------------------------

--- a/Graphics/Implicit/Export/SymbolicFormats.hs
+++ b/Graphics/Implicit/Export/SymbolicFormats.hs
@@ -12,7 +12,7 @@ module Graphics.Implicit.Export.SymbolicFormats (scad2, scad3) where
 
 import Prelude((.), fmap, Either(Left, Right), ($), (*), ($!), (-), (/), pi, error, (+), (==), take, floor, (&&), const, pure, (<>), sequenceA, (<$>))
 
-import Graphics.Implicit.Definitions(ℝ, SymbolicObj2(Shared2, Square, Circle, Polygon, Rotate2, Transform2), SymbolicObj3(Shared3, Cube, Sphere, Cylinder, Rotate3, Transform3, Extrude, ExtrudeM, RotateExtrude, ExtrudeOnEdgeOf), isScaleID, SharedObj(Empty, Full, Complement, UnionR, IntersectR, DifferenceR, Translate, Scale, Mirror, Outset, Shell, EmbedBoxedObj, WithRounding), quaternionToEuler)
+import Graphics.Implicit.Definitions(ℝ, SymbolicObj2(Shared2, Square, Circle, Polygon, Rotate2, Transform2), SymbolicObj3(Shared3, Cube, Sphere, Cylinder, Rotate3, Transform3, Extrude, ExtrudeM, RotateExtrude, ExtrudeOnEdgeOf, Torus, Ellipsoid), isScaleID, SharedObj(Empty, Full, Complement, UnionR, IntersectR, DifferenceR, Translate, Scale, Mirror, Outset, Shell, EmbedBoxedObj, WithRounding), quaternionToEuler)
 import Graphics.Implicit.Export.TextBuilderUtils(Text, Builder, toLazyText, fromLazyText, bf)
 
 import Control.Monad.Reader (Reader, runReader, ask)
@@ -126,6 +126,10 @@ buildS3 (Shared3 obj) = buildShared obj
 buildS3 (Cube (V3 w d h)) = call "cube" [bf w, bf d, bf h] []
 
 buildS3 (Sphere r) = callNaked "sphere" ["r = " <> bf r] []
+
+buildS3 (Torus r1 r2) = callNaked "torus" ["r1 = " <> bf r1, "r2 = " <> bf r2]  []
+
+buildS3 (Ellipsoid a b c) = callNaked "ellipsoid" ["a = " <> bf a, "b = " <> bf b, "c = " <> bf c] []
 
 buildS3 (Cylinder h r1 r2) = callNaked "cylinder" [
                               "r1 = " <> bf r1

--- a/Graphics/Implicit/ObjectUtil/GetBox3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetBox3.hs
@@ -12,7 +12,7 @@ import Graphics.Implicit.Definitions
     ( Fastℕ,
       fromFastℕ,
       ExtrudeMScale(C2, C1),
-      SymbolicObj3(Shared3, Cube, Sphere, Cylinder, Rotate3, Transform3, Extrude, ExtrudeOnEdgeOf, ExtrudeM, RotateExtrude),
+      SymbolicObj3(Shared3, Cube, Sphere, Cylinder, Rotate3, Transform3, Extrude, ExtrudeOnEdgeOf, ExtrudeM, RotateExtrude, Torus, Ellipsoid),
       Box3,
       ℝ,
       fromFastℕtoℝ,
@@ -34,6 +34,10 @@ getBox3 (Shared3 obj) = getBoxShared obj
 getBox3 (Cube size) = (pure 0, size)
 getBox3 (Sphere r) = (pure (-r), pure r)
 getBox3 (Cylinder h r1 r2) = (V3 (-r) (-r) 0, V3 r r h ) where r = max r1 r2
+getBox3 (Torus r1 r2) =
+  let r = r1 + r2
+  in (V3 (-r) (-r) (-r2), V3 r r r2)
+getBox3 (Ellipsoid a b c) = (V3 (-a) (-b) (-c), V3 a b c)
 -- (Rounded) CSG
 -- Simple transforms
 getBox3 (Rotate3 q symbObj) =

--- a/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
+++ b/Graphics/Implicit/ObjectUtil/GetImplicit3.hs
@@ -6,10 +6,10 @@
 
 module Graphics.Implicit.ObjectUtil.GetImplicit3 (getImplicit3) where
 
-import Prelude (id, (||), (/=), either, round, fromInteger, Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, cos, minimum, ($), sin, pi, (.), Bool(True, False), ceiling, floor, pure, (==), otherwise)
+import Prelude (id, (||), (/=), either, round, fromInteger, Either(Left, Right), abs, (-), (/), (*), sqrt, (+), atan2, max, cos, minimum, ($), sin, pi, (.), Bool(True, False), ceiling, floor, pure, (==), otherwise, (**))
 
 import Graphics.Implicit.Definitions
-    ( objectRounding, ObjectContext, ℕ, SymbolicObj3(Cube, Sphere, Cylinder, Rotate3, Transform3, Extrude, ExtrudeM, ExtrudeOnEdgeOf, RotateExtrude, Shared3), Obj3, ℝ2, ℝ, fromℕtoℝ, toScaleFn )
+    ( objectRounding, ObjectContext, ℕ, SymbolicObj3(Cube, Sphere, Cylinder, Rotate3, Transform3, Extrude, ExtrudeM, ExtrudeOnEdgeOf, RotateExtrude, Shared3, Torus, Ellipsoid), Obj3, ℝ2, ℝ, fromℕtoℝ, toScaleFn )
 
 import Graphics.Implicit.MathUtil ( rmax, rmaximum )
 
@@ -31,6 +31,8 @@ getImplicit3 ctx (Cube (V3 dx dy dz)) =
     \(V3 x y z) -> rmaximum (objectRounding ctx) [abs (x-dx/2) - dx/2, abs (y-dy/2) - dy/2, abs (z-dz/2) - dz/2]
 getImplicit3 _ (Sphere r) =
     \(V3 x y z) -> sqrt (x*x + y*y + z*z) - r
+getImplicit3 _ (Torus r1 r2) =  \(V3 x y z) -> let a = (sqrt (x**2 + y**2) - r1) in a**2 + z**2 - r2**2
+getImplicit3 _ (Ellipsoid a b c) = \(V3 x y z) -> (x**2/a**2) + (y**2/b**2) + (z**2/c**2) - 1
 getImplicit3 _ (Cylinder h r1 r2) = \(V3 x y z) ->
     let
         d = sqrt (x*x + y*y) - ((r2-r1)/h*z+r1)

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -91,7 +91,8 @@ import Graphics.Implicit.Definitions (ObjectContext, ℝ, ℝ2, ℝ3, Box2,
                                                    ExtrudeM,
                                                    RotateExtrude,
                                                    ExtrudeOnEdgeOf,
-                                                   Shared3, Ellipsoid
+                                                   Shared3,
+                                                   Ellipsoid
                                                   ),
                                       ExtrudeMScale,
                                       defaultObjectContext

--- a/Graphics/Implicit/Primitives.hs
+++ b/Graphics/Implicit/Primitives.hs
@@ -53,7 +53,7 @@ module Graphics.Implicit.Primitives (
                                      pattern Shared,
                                      Object(Space, canonicalize)) where
 
-import Prelude(Applicative, Eq, Foldable, Num, abs, (<), otherwise, Num, (+), (-), (*), (/), (.), negate, Bool(True, False), Maybe(Just, Nothing), Either, fmap, ($), (**), sqrt, (<=), (&&), max, Ord)
+import Prelude(Applicative, Eq, Foldable, Num, abs, (<), otherwise, Num, (-), (*), (/), (.), negate, Bool(True, False), Maybe(Just, Nothing), Either, fmap, ($), (<=), (&&), max, Ord)
 
 import Graphics.Implicit.Canon (canonicalize2, canonicalize3)
 import Graphics.Implicit.Definitions (ObjectContext, ℝ, ℝ2, ℝ3, Box2,
@@ -84,13 +84,14 @@ import Graphics.Implicit.Definitions (ObjectContext, ℝ, ℝ2, ℝ3, Box2,
                                                    Cube,
                                                    Sphere,
                                                    Cylinder,
+                                                   Torus,
                                                    Rotate3,
                                                    Transform3,
                                                    Extrude,
                                                    ExtrudeM,
                                                    RotateExtrude,
                                                    ExtrudeOnEdgeOf,
-                                                   Shared3
+                                                   Shared3, Ellipsoid
                                                   ),
                                       ExtrudeMScale,
                                       defaultObjectContext
@@ -147,16 +148,10 @@ cone ::
 cone = cylinder2 0
 
 torus :: ℝ -> ℝ -> SymbolicObj3 -- Major radius, minor radius
-torus r1 r2 = implicit
-    (\(V3 x y z) -> let a = (sqrt (x**2 + y**2) - r1) in a**2 + z**2 - r2**2)
-    (V3 (-r) (-r) (-r2), V3 r r r2)
-    where
-        r = r1 + r2
+torus = Torus
 
 ellipsoid :: ℝ -> ℝ -> ℝ -> SymbolicObj3 -- a, b, c
-ellipsoid a b c = implicit
-    (\(V3 x y z) -> (x**2/a**2) + (y**2/b**2) + (z**2/c**2) - 1)
-    (V3 (-a) (-b) (-c), V3 a b c)
+ellipsoid = Ellipsoid
 
 -- $ 2D Primitives
 


### PR DESCRIPTION
Fix for https://github.com/Haskell-Things/ImplicitCAD/issues/450

Switching the definitions of torus and ellipsoid to be SymbolicObj3 primitives rather than being `implict`ly defined. The maths functions haven't changed, only been moved around.

One test was updated as some of the STL values changed, but to the eye it looks similar, and a random check of values indicated that they were small.