### PR TITLE
Fixing some partial function warnings being emitted by GHC

### DIFF
--- a/Graphics/Implicit/Export/OutputFormat.hs
+++ b/Graphics/Implicit/Export/OutputFormat.hs
@@ -16,16 +16,19 @@ module Graphics.Implicit.Export.OutputFormat
   )
 where
 
-import Prelude (Bool, Eq, FilePath, Maybe, Read (readsPrec), Show(show), String, drop, error, flip, length, tail, take, ($), (<>), (==))
+import Prelude (Bool, Eq, FilePath, Maybe, Read (readsPrec), Show(show), String, drop, error, flip, length, take, ($), (<>), (==), snd)
 import Control.Applicative ((<$>))
 -- For making the format guesser case insensitive when looking at file extensions.
 import Data.Char (toLower)
 import Data.Default.Class (Default(def))
-import Data.List (lookup, elem)
+import Data.List (lookup, elem, uncons)
 import Data.Maybe (fromMaybe)
 import Data.Tuple (swap)
 -- For handling input/output files.
 import System.FilePath (takeExtensions)
+
+tail :: [a] -> [a]
+tail l = fromMaybe [] $ snd <$> uncons l
 
 -- | A type serving to enumerate our output formats.
 data OutputFormat

--- a/Graphics/Implicit/Export/Render.hs
+++ b/Graphics/Implicit/Export/Render.hs
@@ -8,7 +8,7 @@
 -- export getContour and getMesh, which returns the edge of a 2D object, or the surface of a 3D object, respectively.
 module Graphics.Implicit.Export.Render (getMesh, getContour) where
 
-import Prelude(error, (-), ceiling, ($), (+), (*), max, div, tail, fmap, reverse, (.), foldMap, min, Int, (<>), (<$>), traverse)
+import Prelude(error, (-), ceiling, ($), (+), (*), max, div, fmap, reverse, (.), foldMap, min, Int, (<>), (<$>), traverse, snd)
 
 import Graphics.Implicit.Definitions (ℝ, ℕ, Fastℕ, ℝ2, ℝ3, TriangleMesh, Obj2, SymbolicObj2, Obj3, SymbolicObj3, Polyline(getSegments), (⋯/), fromℕtoℝ, fromℕ, ℝ3' (ℝ3'))
 
@@ -71,9 +71,13 @@ import Graphics.Implicit.Export.Render.HandlePolylines (cleanLoopsFromSegs)
 import Data.Maybe (fromMaybe)
 import Graphics.Implicit.Primitives (getImplicit)
 import Control.Lens (_Wrapped, view, over, _Just)
+import Data.List (uncons)
 
 -- Set the default types for the numbers in this file.
 default (ℕ, Fastℕ, ℝ)
+
+tail :: [a] -> [a]
+tail l = fromMaybe [] $ snd <$> uncons l
 
 getMesh :: ℝ3 -> SymbolicObj3 -> TriangleMesh
 getMesh res@(V3 xres yres zres) symObj =

--- a/Graphics/Implicit/Export/Render/TesselateLoops.hs
+++ b/Graphics/Implicit/Export/Render/TesselateLoops.hs
@@ -4,7 +4,7 @@
 
 module Graphics.Implicit.Export.Render.TesselateLoops (tesselateLoop) where
 
-import Prelude(sum, (-), pure, ($), length, (==), zip, init, tail, reverse, (<), (/), null, (<>), head, (*), abs, (+), foldMap, (&&))
+import Prelude(sum, (-), pure, ($), length, (==), zip, init, reverse, (<), (/), null, (<>), head, (*), abs, (+), foldMap, (&&), snd, (<$>))
 
 import Graphics.Implicit.Definitions (ℝ, ℕ, Obj3, ℝ3, TriangleMesh(TriangleMesh), Triangle(Triangle))
 
@@ -12,8 +12,12 @@ import Graphics.Implicit.Export.Render.Definitions (TriSquare(Tris))
 
 import Graphics.Implicit.Export.Util (centroid)
 
-import Data.List (genericLength)
+import Data.List (genericLength, uncons)
 import Linear ( cross, Metric(norm), (^*), (^/) )
+import Data.Maybe (fromMaybe)
+
+tail :: [a] -> [a]
+tail l = fromMaybe [] $ snd <$> uncons l
 
 -- de-compose a loop into a series of triangles or squares.
 -- FIXME: res should be ℝ3.

--- a/programs/docgen.hs
+++ b/programs/docgen.hs
@@ -4,7 +4,9 @@
 -- FIXME: document why we need each of these.
 {-# LANGUAGE ScopedTypeVariables  #-}
 
-import Prelude(IO, Show, String, Int, Maybe(Just,Nothing), Eq, return, ($), show, fmap, (<>), putStrLn, filter, zip, null, undefined, const, Bool(True,False), fst, (.), head, tail, length, (/=), (+), error, print)
+import Prelude(IO, Show, String, Int, Maybe(Just,Nothing), Eq, return, ($), show, fmap, (<>), putStrLn, filter, zip, null, undefined, const, Bool(True,False), fst, (.), head, length, (/=), (+), error, print, snd, (<$>))
+import Data.Maybe (fromMaybe)
+import Data.List (uncons)
 import Graphics.Implicit.ExtOpenScad.Primitives (primitiveModules)
 import Graphics.Implicit.ExtOpenScad.Definitions (ArgParser(AP,APFail,APExample,APTest,APTerminator,APBranch), Symbol(Symbol), OVal(ONModule), SourcePosition(SourcePosition), StateC)
 
@@ -12,6 +14,9 @@ import qualified Control.Exception as Ex (catch, SomeException)
 import Control.Monad (forM_)
 import Data.Traversable (traverse)
 import Data.Text.Lazy (unpack, pack)
+
+tail :: [a] -> [a]
+tail l = fromMaybe [] $ snd <$> uncons l
 
 -- | Return true if the argument is of type ExampleDoc.
 isExample :: DocPart -> Bool


### PR DESCRIPTION
Replacing `tail` with a varient that emits an empty list when the input list is also empty. Otherwise it behaves as `Prelude.tail`