### PR TITLE
Removing more partial functions the GHC picked up.

### DIFF
--- a/Graphics/Implicit/Export/OutputFormat.hs
+++ b/Graphics/Implicit/Export/OutputFormat.hs
@@ -16,19 +16,19 @@ module Graphics.Implicit.Export.OutputFormat
   )
 where
 
-import Prelude (Bool, Eq, FilePath, Maybe, Read (readsPrec), Show(show), String, drop, error, flip, length, take, ($), (<>), (==), snd)
+import Prelude (Bool, Eq, FilePath, Maybe, Read (readsPrec), Show(show), String, drop, error, flip, length, take, ($), (<>), (==))
 import Control.Applicative ((<$>))
 -- For making the format guesser case insensitive when looking at file extensions.
 import Data.Char (toLower)
 import Data.Default.Class (Default(def))
-import Data.List (lookup, elem, uncons)
+import Data.List (lookup, elem)
 import Data.Maybe (fromMaybe)
 import Data.Tuple (swap)
 -- For handling input/output files.
 import System.FilePath (takeExtensions)
 
 tail :: [a] -> [a]
-tail l = fromMaybe [] $ snd <$> uncons l
+tail = drop 1
 
 -- | A type serving to enumerate our output formats.
 data OutputFormat

--- a/Graphics/Implicit/Export/Render.hs
+++ b/Graphics/Implicit/Export/Render.hs
@@ -8,7 +8,7 @@
 -- export getContour and getMesh, which returns the edge of a 2D object, or the surface of a 3D object, respectively.
 module Graphics.Implicit.Export.Render (getMesh, getContour) where
 
-import Prelude(error, (-), ceiling, ($), (+), (*), max, div, fmap, reverse, (.), foldMap, min, Int, (<>), (<$>), traverse, snd)
+import Prelude(error, (-), ceiling, ($), (+), (*), max, div, fmap, reverse, (.), foldMap, min, Int, (<>), (<$>), traverse, drop)
 
 import Graphics.Implicit.Definitions (ℝ, ℕ, Fastℕ, ℝ2, ℝ3, TriangleMesh, Obj2, SymbolicObj2, Obj3, SymbolicObj3, Polyline(getSegments), (⋯/), fromℕtoℝ, fromℕ, ℝ3' (ℝ3'))
 
@@ -71,13 +71,12 @@ import Graphics.Implicit.Export.Render.HandlePolylines (cleanLoopsFromSegs)
 import Data.Maybe (fromMaybe)
 import Graphics.Implicit.Primitives (getImplicit)
 import Control.Lens (_Wrapped, view, over, _Just)
-import Data.List (uncons)
 
 -- Set the default types for the numbers in this file.
 default (ℕ, Fastℕ, ℝ)
 
 tail :: [a] -> [a]
-tail l = fromMaybe [] $ snd <$> uncons l
+tail = drop 1
 
 getMesh :: ℝ3 -> SymbolicObj3 -> TriangleMesh
 getMesh res@(V3 xres yres zres) symObj =

--- a/Graphics/Implicit/Export/Render/GetLoops.hs
+++ b/Graphics/Implicit/Export/Render/GetLoops.hs
@@ -5,7 +5,7 @@
 module Graphics.Implicit.Export.Render.GetLoops (getLoops) where
 
 -- Explicitly include what we want from Prelude.
-import Prelude ((<$>), head, last, (==), Bool(False), (.), null, (<>), Eq, Maybe(Just, Nothing))
+import Prelude ((<$>), last, (==), Bool(False), (.), null, (<>), Eq, Maybe(Just, Nothing))
 
 import Data.List (partition)
 
@@ -51,7 +51,7 @@ getLoops' (x:xs) [] _ = getLoops' xs [x] (last x)
 
 -- A loop is finished if its start and end are the same.
 -- Return it and start searching for another loop.
-getLoops' segs workingLoop ultima | head (head workingLoop) == ultima =
+getLoops' segs workingLoop@((x:_):_) ultima | x == ultima =
     (workingLoop :) <$> getLoops' segs [] ultima
 
 -- Finally, we search for pieces that can continue the working loop,

--- a/Graphics/Implicit/ExtOpenScad/Parser/Expr.hs
+++ b/Graphics/Implicit/ExtOpenScad/Parser/Expr.hs
@@ -12,7 +12,7 @@
 -- A parser for a numeric expressions.
 module Graphics.Implicit.ExtOpenScad.Parser.Expr(expr0) where
 
-import Prelude (Char, Maybe(Nothing, Just), ($), (<>), id, foldl, foldr, (==), length, head, (&&), (<$>), (<*>), (*>), (<*), flip, (.), pure)
+import Prelude (Char, Maybe(Nothing, Just), ($), (<>), id, foldl, foldr, (==), (<$>), (<*>), (*>), (<*), flip, (.), pure, Bool (True))
 
 import Graphics.Implicit.ExtOpenScad.Definitions (Expr(LamE, LitE, ListE, (:$)), OVal(ONum, OUndefined), Symbol(Symbol))
 
@@ -147,9 +147,9 @@ vectorListParentheses =
               <* if o == '['
                  then matchTok ']'
                  else matchTok ')'
-            pure $ if o == '(' && length exprs == 1
-                     then head exprs
-                     else ListE exprs
+            pure $ case (o == '(', exprs) of
+                (True, [e]) -> e
+                _ -> ListE exprs
     *<|> "vector/list generator" ?: do
         -- eg.  [ a : 1 : a + 10 ]
         --      [ a : a + 10 ]

--- a/programs/docgen.hs
+++ b/programs/docgen.hs
@@ -4,9 +4,7 @@
 -- FIXME: document why we need each of these.
 {-# LANGUAGE ScopedTypeVariables  #-}
 
-import Prelude(IO, Show, String, Int, Maybe(Just,Nothing), Eq, return, ($), show, fmap, (<>), putStrLn, filter, zip, null, undefined, const, Bool(True,False), fst, (.), head, length, (/=), (+), error, print, snd, (<$>))
-import Data.Maybe (fromMaybe)
-import Data.List (uncons)
+import Prelude(IO, Show, String, Int, Maybe(Just,Nothing), Eq, return, ($), show, fmap, (<>), putStrLn, filter, zip, null, undefined, const, Bool(True,False), fst, (.), head, length, (/=), (+), error, print, drop)
 import Graphics.Implicit.ExtOpenScad.Primitives (primitiveModules)
 import Graphics.Implicit.ExtOpenScad.Definitions (ArgParser(AP,APFail,APExample,APTest,APTerminator,APBranch), Symbol(Symbol), OVal(ONModule), SourcePosition(SourcePosition), StateC)
 
@@ -16,7 +14,7 @@ import Data.Traversable (traverse)
 import Data.Text.Lazy (unpack, pack)
 
 tail :: [a] -> [a]
-tail l = fromMaybe [] $ snd <$> uncons l
+tail = drop 1
 
 -- | Return true if the argument is of type ExampleDoc.
 isExample :: DocPart -> Bool


### PR DESCRIPTION
Removing instances of `head` that GHC is flagging, except for one in command line arguement parsing.

Reworked the `tail` replacement to use `drop 1` rather than using `uncons`, as I wasn't happy with the previous version.